### PR TITLE
Fix decorator placement in injectable class

### DIFF
--- a/host-frontend-root/frontend-src-root/src/application/usecases/contextmenu/HandleContextMenuSelectionUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/contextmenu/HandleContextMenuSelectionUseCase.ts
@@ -7,8 +7,9 @@ import { ISelectedPageTextRepository } from 'src/application/ports/ISelectedPage
 /**
  * コンテキストメニューからのDOM要素置換処理を扱うユースケース
  */
+export
 @injectable()
-export class HandleContextMenuReplaceDomElement {
+class HandleContextMenuReplaceDomElement {
   constructor(
     @inject('IChromeTabsService') private readonly tabsService: IChromeTabsService,
     @inject('ISelectedPageTextRepository') private readonly selectedPageTextRepository: ISelectedPageTextRepository,

--- a/host-frontend-root/frontend-src-root/src/application/usecases/popup/PopupInitFormUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/popup/PopupInitFormUseCase.ts
@@ -12,8 +12,9 @@ interface PopupInitFormResult {
  * ポップアップのフォーム初期化を行うUseCase
  * 右クリック選択テキストと現在のタブのoriginを取得してフォームを初期化する
  */
+export
 @injectable()
-export class PopupInitFormUseCase {
+class PopupInitFormUseCase {
   constructor(
     @inject('ICurrentTabService') private currentTabService: ICurrentTabService,
     @inject('ISelectedPageTextRepository') private selectedPageTextRepository: ISelectedPageTextRepository

--- a/host-frontend-root/frontend-src-root/src/application/usecases/rule/LoadRewriteRuleForEditUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/rule/LoadRewriteRuleForEditUseCase.ts
@@ -3,8 +3,9 @@ import { inject,injectable } from 'tsyringe';
 import { IRewriteRuleRepository } from 'src/application/ports/IRewriteRuleRepository';
 import { RewriteRule } from 'src/domain/entities/RewriteRule/RewriteRule';
 
+export
 @injectable()
-export class LoadRewriteRuleForEditUseCase {
+class LoadRewriteRuleForEditUseCase {
   constructor(
     @inject('IRewriteRuleRepository')
     private readonly rewriteRuleRepository: IRewriteRuleRepository

--- a/host-frontend-root/frontend-src-root/src/application/usecases/rule/SaveRewriteRuleAndApplyToCurrentTabUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/rule/SaveRewriteRuleAndApplyToCurrentTabUseCase.ts
@@ -16,8 +16,9 @@ interface SaveRewriteRuleAndApplyResult {
 /**
  * リライトルールを保存し、現在のタブに適用するUseCase
  */
+export
 @injectable()
-export class SaveRewriteRuleAndApplyToCurrentTabUseCase {
+class SaveRewriteRuleAndApplyToCurrentTabUseCase {
   constructor(
     @inject('IRewriteRuleRepository') private repository: IRewriteRuleRepository,
     @inject('ICurrentTabService') private currentTabService: ICurrentTabService,

--- a/host-frontend-root/frontend-src-root/src/application/usecases/rule/UpdateRewriteRuleUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/rule/UpdateRewriteRuleUseCase.ts
@@ -7,8 +7,9 @@ import { RewriteRule } from 'src/domain/entities/RewriteRule/RewriteRule';
 import { Tab } from 'src/domain/value-objects/Tab';
 import { Tabs } from 'src/domain/value-objects/Tabs';
 
+export
 @injectable()
-export class UpdateRewriteRuleUseCase {
+class UpdateRewriteRuleUseCase {
   constructor(
     @inject('IRewriteRuleRepository')
     private readonly rewriteRuleRepository: IRewriteRuleRepository,

--- a/host-frontend-root/frontend-src-root/src/application/usecases/window/CloseCurrentWindowUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/window/CloseCurrentWindowUseCase.ts
@@ -2,8 +2,9 @@ import { inject,injectable } from 'tsyringe';
 
 import { IWindowService } from 'src/application/ports/IWindowService';
 
+export
 @injectable()
-export class CloseCurrentWindowUseCase {
+class CloseCurrentWindowUseCase {
   constructor(
     @inject('IWindowService')
     private readonly windowService: IWindowService

--- a/host-frontend-root/frontend-src-root/src/infrastructure/browser/tabs/ChromeTabsService.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/browser/tabs/ChromeTabsService.ts
@@ -7,8 +7,9 @@ import { Tabs } from 'src/domain/value-objects/Tabs';
 /**
  * Chrome Tabs APIを使用して現在のタブにメッセージを送信するサービスの実装
  */
+export
 @injectable()
-export class ChromeTabsService implements IChromeTabsService {
+class ChromeTabsService implements IChromeTabsService {
   async sendMessage(tabId: number, message: any): Promise<any> {
     try {
       const response = await chrome.tabs.sendMessage(tabId, message);


### PR DESCRIPTION
Move @injectable() decorator after export keyword to fix Storybook syntax errors. The new format uses TypeScript 5.0+ syntax: export
@injectable()
class ClassName