### PR TITLE
Migrate DI resolution to awilix in content

### DIFF
--- a/host-frontend-root/frontend-src-root/src/infrastructure/browser/content/instance/domMutationUseCaseInstance.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/browser/content/instance/domMutationUseCaseInstance.ts
@@ -1,8 +1,5 @@
 import { ApplyRulesOnDomMutationUseCase } from 'src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase';
-import { observerControl } from 'src/infrastructure/browser/content/observer/observerState';
-import { ChromeRuntimeRewriteRuleRepository } from 'src/infrastructure/browser/messaging/ChromeRuntimeRewriteRuleRepository';
-import { DebounceTimer } from 'src/infrastructure/browser/timer/DebounceTimer';
-import { WindowCurrentUrlService } from 'src/infrastructure/browser/window/WindowCurrentUrlService';
+import { contentContainer } from 'src/infrastructure/di/contentContainer';
 
 /**
  * Content Script用のApplyRulesOnDomMutationUseCaseシングルトンインスタンス
@@ -10,19 +7,6 @@ import { WindowCurrentUrlService } from 'src/infrastructure/browser/window/Windo
  * ページロード時のルール適用（applyRulesToRoot）とDOM Mutation時のルール適用（handleMutations）
  * の両方で同一インスタンスを使用することで、状態管理を簡素化する
  *
- * 手動DI解決: tsyringeのデコレーターメタデータ問題を回避するため
- * Content Scriptではデコレーターが正しく動作しないので、依存関係を明示的にインスタンス化
- *
- * observerControl: observerState.tsから取得
- * - observer状態を別モジュールに分離することで循環参照を回避
+ * Awilix DIコンテナから解決: contentContainer.tsで登録されたインスタンスを取得
  */
-const repository = new ChromeRuntimeRewriteRuleRepository();
-const currentUrlService = new WindowCurrentUrlService();
-const debounceTimer = new DebounceTimer();
-
-export const domMutationUseCaseInstance = new ApplyRulesOnDomMutationUseCase(
-  repository,
-  currentUrlService,
-  debounceTimer,
-  observerControl
-);
+export const domMutationUseCaseInstance = contentContainer.resolve(ApplyRulesOnDomMutationUseCase);

--- a/host-frontend-root/frontend-src-root/src/infrastructure/browser/handlers/content/getElementSelectionHandler.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/browser/handlers/content/getElementSelectionHandler.ts
@@ -1,5 +1,6 @@
 // cspell:ignore usecases
 import { GetElementSelectionUseCase } from 'src/application/usecases/selection/GetElementSelectionUseCase';
+import { contentContainer } from 'src/infrastructure/di/contentContainer';
 
 type GetElementSelectionMessage = { type: 'getElementSelection' };
 
@@ -14,9 +15,11 @@ type GetElementSelectionMessage = { type: 'getElementSelection' };
  * 2. listeners/runtime/content.onMessage.ts の registerRuntimeOnMessageForContent が message を route 関数に渡す
  * 3. router/content/messageRouter.ts の createContentMessageRouter が message を適切な handler に振り分ける
  * 4. このハンドラーが呼び出される（router/content/messageRouter.ts の handler(message)）
+ *
+ * Awilix DIコンテナから解決: contentContainer.tsで登録されたインスタンスを取得
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
 export const getElementSelectionHandler = async (_msg: GetElementSelectionMessage) => {
-  const getElementSelectionUseCase = new GetElementSelectionUseCase();
+  const getElementSelectionUseCase = contentContainer.resolve(GetElementSelectionUseCase);
   return getElementSelectionUseCase.getElementSelectionInfo();
 };

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
@@ -1,0 +1,96 @@
+import { asValue, createContainer } from 'awilix';
+
+import { ICurrentUrlService } from 'src/application/ports/ICurrentUrlService';
+import { IDebounceTimer } from 'src/application/ports/IDebounceTimer';
+import { IGetSelectionService } from 'src/application/ports/IGetSelectionService';
+import { IObserverControl } from 'src/application/ports/IObserverControl';
+import { IRewriteRuleRepository } from 'src/application/ports/IRewriteRuleRepository';
+import { ApplyRulesOnDomMutationUseCase } from 'src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase';
+import { GetElementSelectionUseCase } from 'src/application/usecases/selection/GetElementSelectionUseCase';
+import { observerControl } from 'src/infrastructure/browser/content/observer/observerState';
+import { ChromeRuntimeRewriteRuleRepository } from 'src/infrastructure/browser/messaging/ChromeRuntimeRewriteRuleRepository';
+import { DebounceTimer } from 'src/infrastructure/browser/timer/DebounceTimer';
+import { WindowCurrentUrlService } from 'src/infrastructure/browser/window/WindowCurrentUrlService';
+import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
+
+// Create Awilix container for content script
+const awilixContainer = createContainer({
+  strict: true
+});
+
+// Infrastructure services (singleton instances)
+const chromeRuntimeRewriteRuleRepository = new ChromeRuntimeRewriteRuleRepository();
+const windowCurrentUrlService = new WindowCurrentUrlService();
+const debounceTimer = new DebounceTimer();
+const getSelectionService = new GetSelectionService();
+
+// Use Cases (singleton instances with manual dependency injection)
+// ミニファイ後もパラメータ名に依存しないよう、手動でインスタンスを生成
+const applyRulesOnDomMutationUseCase = new ApplyRulesOnDomMutationUseCase(
+  chromeRuntimeRewriteRuleRepository,
+  windowCurrentUrlService,
+  debounceTimer,
+  observerControl
+);
+
+const getElementSelectionUseCase = new GetElementSelectionUseCase(getSelectionService);
+
+// Register all instances with asValue (no automatic injection needed)
+awilixContainer.register({
+  // Infrastructure services
+  chromeRuntimeRewriteRuleRepository: asValue(chromeRuntimeRewriteRuleRepository),
+  windowCurrentUrlService: asValue(windowCurrentUrlService),
+  debounceTimer: asValue(debounceTimer),
+  observerControl: asValue(observerControl),
+  getSelectionService: asValue(getSelectionService),
+
+  // Use Cases
+  applyRulesOnDomMutationUseCase: asValue(applyRulesOnDomMutationUseCase),
+  getElementSelectionUseCase: asValue(getElementSelectionUseCase)
+});
+
+// Type definitions for container resolution
+interface ContentContainerCradle {
+  // Interface implementations
+  chromeRuntimeRewriteRuleRepository: IRewriteRuleRepository;
+  windowCurrentUrlService: ICurrentUrlService;
+  debounceTimer: IDebounceTimer;
+  observerControl: IObserverControl;
+  getSelectionService: IGetSelectionService;
+
+  // Use Cases
+  applyRulesOnDomMutationUseCase: ApplyRulesOnDomMutationUseCase;
+  getElementSelectionUseCase: GetElementSelectionUseCase;
+}
+
+// Class to key mappings for class-based resolution
+const classToKeyMap = new Map<Function, keyof ContentContainerCradle>([
+  [ApplyRulesOnDomMutationUseCase, 'applyRulesOnDomMutationUseCase'],
+  [GetElementSelectionUseCase, 'getElementSelectionUseCase'],
+  [ChromeRuntimeRewriteRuleRepository, 'chromeRuntimeRewriteRuleRepository'],
+  [WindowCurrentUrlService, 'windowCurrentUrlService'],
+  [DebounceTimer, 'debounceTimer'],
+  [GetSelectionService, 'getSelectionService']
+]);
+
+// Container interface with overloaded resolve
+interface ContentContainer {
+  resolve(token: typeof ApplyRulesOnDomMutationUseCase): ApplyRulesOnDomMutationUseCase;
+  resolve(token: typeof GetElementSelectionUseCase): GetElementSelectionUseCase;
+  resolve(token: typeof ChromeRuntimeRewriteRuleRepository): ChromeRuntimeRewriteRuleRepository;
+  resolve(token: typeof WindowCurrentUrlService): WindowCurrentUrlService;
+  resolve(token: typeof DebounceTimer): DebounceTimer;
+  resolve(token: typeof GetSelectionService): GetSelectionService;
+  resolve<T>(token: Function): T;
+}
+
+// Wrapper to provide container API
+export const contentContainer: ContentContainer = {
+  resolve(token: Function): any {
+    const key = classToKeyMap.get(token);
+    if (!key) {
+      throw new Error(`Unknown class token: ${(token as any).name}`);
+    }
+    return awilixContainer.resolve(key);
+  }
+};

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/concrete-class-registration-completeness.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApplyRulesOnDomMutationUseCase } from 'src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase';
+import { GetElementSelectionUseCase } from 'src/application/usecases/selection/GetElementSelectionUseCase';
+import { ChromeRuntimeRewriteRuleRepository } from 'src/infrastructure/browser/messaging/ChromeRuntimeRewriteRuleRepository';
+import { DebounceTimer } from 'src/infrastructure/browser/timer/DebounceTimer';
+import { WindowCurrentUrlService } from 'src/infrastructure/browser/window/WindowCurrentUrlService';
+import { contentContainer } from 'src/infrastructure/di/contentContainer';
+import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
+
+/**
+ * Content Script用DIコンテナの具体クラス登録確認テスト (Awilix)
+ * contentContainer.resolve()で具体クラスを解決できることを検証する
+ */
+describe('Content DI Container - 具体クラス登録確認テスト (Awilix)', () => {
+  /**
+   * 具体クラス解決テストケース
+   * 各クラスがcontentContainer.resolve()で正しく解決できることを検証する
+   */
+  const testCases = [
+    {
+      description: 'ApplyRulesOnDomMutationUseCaseを解決できること',
+      input: { classToken: ApplyRulesOnDomMutationUseCase },
+      expected: { className: 'ApplyRulesOnDomMutationUseCase' }
+    },
+    {
+      description: 'GetElementSelectionUseCaseを解決できること',
+      input: { classToken: GetElementSelectionUseCase },
+      expected: { className: 'GetElementSelectionUseCase' }
+    },
+    {
+      description: 'ChromeRuntimeRewriteRuleRepositoryを解決できること',
+      input: { classToken: ChromeRuntimeRewriteRuleRepository },
+      expected: { className: 'ChromeRuntimeRewriteRuleRepository' }
+    },
+    {
+      description: 'WindowCurrentUrlServiceを解決できること',
+      input: { classToken: WindowCurrentUrlService },
+      expected: { className: 'WindowCurrentUrlService' }
+    },
+    {
+      description: 'DebounceTimerを解決できること',
+      input: { classToken: DebounceTimer },
+      expected: { className: 'DebounceTimer' }
+    },
+    {
+      description: 'GetSelectionServiceを解決できること',
+      input: { classToken: GetSelectionService },
+      expected: { className: 'GetSelectionService' }
+    }
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, () => {
+      // Arrange
+      const { classToken } = testCase.input;
+      const { className } = testCase.expected;
+
+      // Act
+      const resolved = contentContainer.resolve<InstanceType<typeof classToken>>(classToken);
+
+      // Assert
+      expect(resolved).toBeDefined();
+      expect(resolved).not.toBeNull();
+      expect(resolved).toBeInstanceOf(classToken);
+      expect((resolved as any).constructor.name).toBe(className);
+    });
+  });
+});


### PR DESCRIPTION
Introduce contentContainer.ts for content script specific DI resolution, replacing manual instantiation in domMutationUseCaseInstance.ts and getElementSelectionHandler.ts with container.resolve() calls.