### PR TITLE
Fix DI container concrete class registration test

### DIFF
--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -135,7 +135,7 @@ const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
 };
 
 // Class to key mappings for class-based resolution
-const classToKeyMap = new Map<Function, keyof ContainerCradle>([
+export const classToKeyMap = new Map<Function, keyof ContainerCradle>([
   [HandleContextMenuReplaceDomElement, 'handleContextMenuReplaceDomElement'],
   [ContextMenuSetupUseCase, 'contextMenuSetupUseCase'],
   [LoadRewriteRuleForEditUseCase, 'loadRewriteRuleForEditUseCase'],
@@ -162,14 +162,6 @@ interface Container {
   resolve(token: typeof ChromeCurrentTabService): ChromeCurrentTabService;
   resolve<T>(token: InterfaceToken): T;
   resolve<T>(token: Function): T;
-}
-
-/**
- * テスト用: 登録済み具体クラストークンの一覧を取得する
- * DIコンテナに登録されている具体クラスを動的に取得するために使用
- */
-export function getRegisteredConcreteClassTokens(): Array<{ token: Function; key: string }> {
-  return Array.from(classToKeyMap.entries()).map(([token, key]) => ({ token, key }));
 }
 
 // Wrapper to provide tsyringe-compatible API

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -164,6 +164,14 @@ interface Container {
   resolve<T>(token: Function): T;
 }
 
+/**
+ * テスト用: 登録済み具体クラストークンの一覧を取得する
+ * DIコンテナに登録されている具体クラスを動的に取得するために使用
+ */
+export function getRegisteredConcreteClassTokens(): Array<{ token: Function; key: string }> {
+  return Array.from(classToKeyMap.entries()).map(([token, key]) => ({ token, key }));
+}
+
 // Wrapper to provide tsyringe-compatible API
 export const container: Container = {
   resolve(token: InterfaceToken | Function): any {

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -111,10 +111,19 @@ describe('DI Container - 具体クラス登録確認テスト (Awilix)', () => {
     // Assert - 期待される登録数と一致することを確認
     expect(actualRegisteredTokens).toHaveLength(testCases.length);
 
-    // Assert - 期待される各具体クラスがDIコンテナに登録されていることを確認
+    // Assert - 各具体クラスがDIコンテナに登録されていることを確認
     const actualTokenSet = new Set(actualRegisteredTokens.map(({ token }) => token));
     testCases.forEach(({ input: { classToken } }) => {
-      expect(actualTokenSet.has(classToken)).toBe(true);
+      expect(actualTokenSet.has(classToken),
+        `Test case exists for ${classToken.name} but it's not registered in classToKeyMap`
+      ).toBe(true);
     });
-  });
+
+    // Assert - DIコンテナに登録されている各クラスにテストケースが存在することを確認
+    const testCaseTokenSet = new Set(testCases.map(tc => tc.input.classToken));
+    actualRegisteredTokens.forEach(({ token }) => {
+      expect(testCaseTokenSet.has(token),
+        `Class ${(token as any).name} is registered in classToKeyMap but missing a test case`
+      ).toBe(true);
+    });
 });

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -1,4 +1,4 @@
-import { container, getRegisteredConcreteClassTokens } from 'src/infrastructure/di/container';
+import { classToKeyMap, container } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
 
@@ -12,6 +12,14 @@ import { CloseCurrentWindowUseCase } from 'src/application/usecases/window/Close
 import { ChromeCurrentTabService } from 'src/infrastructure/browser/tabs/ChromeCurrentTabService';
 import { ChromeTabsService } from 'src/infrastructure/browser/tabs/ChromeTabsService';
 import { DexieRewriteRuleRepository } from 'src/infrastructure/persistence/indexeddb/DexieRewriteRuleRepository';
+
+/**
+ * DIコンテナから登録済み具体クラストークンの一覧を取得する
+ * container.tsのclassToKeyMapから動的に取得
+ */
+function getRegisteredConcreteClassTokens(): Array<{ token: Function; key: string }> {
+  return Array.from(classToKeyMap.entries()).map(([token, key]) => ({ token, key }));
+}
 
 /**
  * DIコンテナの具体クラス登録確認テスト (Awilix)

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -1,4 +1,4 @@
-import { container } from 'src/infrastructure/di/container';
+import { container, getRegisteredConcreteClassTokens } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
 
@@ -9,6 +9,8 @@ import { LoadRewriteRuleForEditUseCase } from 'src/application/usecases/rule/Loa
 import { SaveRewriteRuleAndApplyToCurrentTabUseCase } from 'src/application/usecases/rule/SaveRewriteRuleAndApplyToCurrentTabUseCase';
 import { UpdateRewriteRuleUseCase } from 'src/application/usecases/rule/UpdateRewriteRuleUseCase';
 import { CloseCurrentWindowUseCase } from 'src/application/usecases/window/CloseCurrentWindowUseCase';
+import { ChromeCurrentTabService } from 'src/infrastructure/browser/tabs/ChromeCurrentTabService';
+import { ChromeTabsService } from 'src/infrastructure/browser/tabs/ChromeTabsService';
 import { DexieRewriteRuleRepository } from 'src/infrastructure/persistence/indexeddb/DexieRewriteRuleRepository';
 
 /**
@@ -60,6 +62,16 @@ describe('DI Container - 具体クラス登録確認テスト (Awilix)', () => {
       description: 'PopupInitFormUseCaseを解決できること',
       input: { classToken: PopupInitFormUseCase },
       expected: { className: 'PopupInitFormUseCase' }
+    },
+    {
+      description: 'ChromeTabsServiceを解決できること',
+      input: { classToken: ChromeTabsService },
+      expected: { className: 'ChromeTabsService' }
+    },
+    {
+      description: 'ChromeCurrentTabServiceを解決できること',
+      input: { classToken: ChromeCurrentTabService },
+      expected: { className: 'ChromeCurrentTabService' }
     }
   ];
 
@@ -77,6 +89,24 @@ describe('DI Container - 具体クラス登録確認テスト (Awilix)', () => {
       expect(resolved).not.toBeNull();
       expect(resolved).toBeInstanceOf(classToken);
       expect((resolved as any).constructor.name).toBe(className);
+    });
+  });
+
+  /**
+   * DIコンテナに登録されている具体クラス数と、テストケースで期待する数が一致することを検証
+   * これにより、DIコンテナに新しいクラスが追加された場合にテストケースの追加漏れを検出できる
+   */
+  it('DIコンテナ登録数とテストケース数が一致すること', () => {
+    // Act - DIコンテナから登録済み具体クラストークンを動的取得
+    const actualRegisteredTokens = getRegisteredConcreteClassTokens();
+
+    // Assert - 期待される登録数と一致することを確認
+    expect(actualRegisteredTokens).toHaveLength(testCases.length);
+
+    // Assert - 期待される各具体クラスがDIコンテナに登録されていることを確認
+    const actualTokenSet = new Set(actualRegisteredTokens.map(({ token }) => token));
+    testCases.forEach(({ input: { classToken } }) => {
+      expect(actualTokenSet.has(classToken)).toBe(true);
     });
   });
 });

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -120,10 +120,11 @@ describe('DI Container - 具体クラス登録確認テスト (Awilix)', () => {
     });
 
     // Assert - DIコンテナに登録されている各クラスにテストケースが存在することを確認
-    const testCaseTokenSet = new Set(testCases.map(tc => tc.input.classToken));
+    const testCaseTokenSet = new Set<Function>(testCases.map(tc => tc.input.classToken));
     actualRegisteredTokens.forEach(({ token }) => {
       expect(testCaseTokenSet.has(token),
         `Class ${(token as any).name} is registered in classToKeyMap but missing a test case`
       ).toBe(true);
     });
+  });
 });


### PR DESCRIPTION
Add mechanism to verify DI container registrations match test expectations. This ensures new class registrations to the container are also added to tests.