### PR TITLE
Implement interface registration completeness tests

### DIFF
--- a/host-frontend-root/frontend-src-root/knip.json
+++ b/host-frontend-root/frontend-src-root/knip.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "ignoreExports": [
-    "interfaceToKeyMap",
     "awilixContainer"
   ],
   "ignore": [

--- a/host-frontend-root/frontend-src-root/knip.json
+++ b/host-frontend-root/frontend-src-root/knip.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "ignoreExports": [
+    "interfaceToKeyMap",
+    "awilixContainer"
+  ],
   "ignore": [
     ".output/**",
     ".wxt/**",

--- a/host-frontend-root/frontend-src-root/knip.json
+++ b/host-frontend-root/frontend-src-root/knip.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreExports": [
-    "awilixContainer"
-  ],
   "ignore": [
     ".output/**",
     ".wxt/**",

--- a/host-frontend-root/frontend-src-root/knip.json
+++ b/host-frontend-root/frontend-src-root/knip.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "ignoreExports": [
+    "interfaceToKeyMap",
+    "classToKeyMap"
+  ],
   "ignore": [
     ".output/**",
     ".wxt/**",

--- a/host-frontend-root/frontend-src-root/knip.json
+++ b/host-frontend-root/frontend-src-root/knip.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreExports": [
-    "interfaceToKeyMap",
-    "classToKeyMap"
-  ],
   "ignore": [
     ".output/**",
     ".wxt/**",

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -123,8 +123,7 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService';
 
-/** @public - exported for test verification of interface registration completeness */
-export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
+const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeTabsService': 'chromeTabsService',
   'IPopupService': 'popupService',
   'IRewriteRuleRepository': 'rewriteRuleRepository',
@@ -185,3 +184,6 @@ export const container: Container = {
     return awilixContainer.resolve(key);
   }
 };
+
+// Attach internal mappings for test introspection (similar to tsyringe's _registry)
+(container as any)._interfaceToKeyMap = interfaceToKeyMap;

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -123,6 +123,7 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService';
 
+/** @public - exported for test verification of interface registration completeness */
 export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeTabsService': 'chromeTabsService',
   'IPopupService': 'popupService',
@@ -134,7 +135,7 @@ export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = 
   'IGetSelectionService': 'getSelectionService'
 };
 
-// Class to key mappings for class-based resolution
+/** @public - exported for test verification of concrete class registration completeness */
 export const classToKeyMap = new Map<Function, keyof ContainerCradle>([
   [HandleContextMenuReplaceDomElement, 'handleContextMenuReplaceDomElement'],
   [ContextMenuSetupUseCase, 'contextMenuSetupUseCase'],

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -123,7 +123,7 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService';
 
-const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
+export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeTabsService': 'chromeTabsService',
   'IPopupService': 'popupService',
   'IRewriteRuleRepository': 'rewriteRuleRepository',

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -24,8 +24,8 @@ import { DexieRewriteRuleRepository } from 'src/infrastructure/persistence/index
 import { SelectedPageTextRepository } from 'src/infrastructure/persistence/storage/SelectedPageTextRepository';
 import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
 
-/** @public - exported for test verification of DI container registrations */
-export const awilixContainer = createContainer({
+// Create Awilix container
+const awilixContainer = createContainer({
   strict: true
 });
 
@@ -185,5 +185,6 @@ export const container: Container = {
   }
 };
 
-// Attach internal mappings for test introspection (similar to tsyringe's _registry)
+// Attach internal data for test introspection (similar to tsyringe's _registry)
 (container as any)._interfaceToKeyMap = interfaceToKeyMap;
+(container as any)._awilixContainer = awilixContainer;

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -25,7 +25,7 @@ import { SelectedPageTextRepository } from 'src/infrastructure/persistence/stora
 import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
 
 // Create Awilix container
-const awilixContainer = createContainer({
+export const awilixContainer = createContainer({
   strict: true
 });
 
@@ -123,8 +123,7 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService';
 
-/** @public - exported for test verification of interface registration completeness */
-export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
+const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeTabsService': 'chromeTabsService',
   'IPopupService': 'popupService',
   'IRewriteRuleRepository': 'rewriteRuleRepository',
@@ -135,8 +134,8 @@ export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = 
   'IGetSelectionService': 'getSelectionService'
 };
 
-/** @public - exported for test verification of concrete class registration completeness */
-export const classToKeyMap = new Map<Function, keyof ContainerCradle>([
+// Class to key mappings for class-based resolution
+const classToKeyMap = new Map<Function, keyof ContainerCradle>([
   [HandleContextMenuReplaceDomElement, 'handleContextMenuReplaceDomElement'],
   [ContextMenuSetupUseCase, 'contextMenuSetupUseCase'],
   [LoadRewriteRuleForEditUseCase, 'loadRewriteRuleForEditUseCase'],

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -187,4 +187,5 @@ export const container: Container = {
 
 // Attach internal data for test introspection (similar to tsyringe's _registry)
 (container as any)._interfaceToKeyMap = interfaceToKeyMap;
+(container as any)._classToKeyMap = classToKeyMap;
 (container as any)._awilixContainer = awilixContainer;

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/container.ts
@@ -24,7 +24,7 @@ import { DexieRewriteRuleRepository } from 'src/infrastructure/persistence/index
 import { SelectedPageTextRepository } from 'src/infrastructure/persistence/storage/SelectedPageTextRepository';
 import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
 
-// Create Awilix container
+/** @public - exported for test verification of DI container registrations */
 export const awilixContainer = createContainer({
   strict: true
 });
@@ -123,7 +123,8 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService';
 
-const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
+/** @public - exported for test verification of interface registration completeness */
+export const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeTabsService': 'chromeTabsService',
   'IPopupService': 'popupService',
   'IRewriteRuleRepository': 'rewriteRuleRepository',

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -1,4 +1,4 @@
-import { classToKeyMap, container } from 'src/infrastructure/di/container';
+import { container } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
 
@@ -14,11 +14,19 @@ import { ChromeTabsService } from 'src/infrastructure/browser/tabs/ChromeTabsSer
 import { DexieRewriteRuleRepository } from 'src/infrastructure/persistence/indexeddb/DexieRewriteRuleRepository';
 
 /**
+ * containerの内部プロパティからclassToKeyMapを動的に取得する
+ * tsyringeの_registry._registryMapと同様のアクセスパターン
+ */
+function getClassToKeyMap(): Map<Function, string> {
+  return (container as any)._classToKeyMap;
+}
+
+/**
  * DIコンテナから登録済み具体クラストークンの一覧を取得する
  * container.tsのclassToKeyMapから動的に取得
  */
 function getRegisteredConcreteClassTokens(): Array<{ token: Function; key: string }> {
-  return Array.from(classToKeyMap.entries()).map(([token, key]) => ({ token, key }));
+  return Array.from(getClassToKeyMap().entries()).map(([token, key]) => ({ token, key }));
 }
 
 /**

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -1,6 +1,14 @@
-import { container } from 'src/infrastructure/di/container';
+import { container, interfaceToKeyMap } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
+
+/**
+ * DIコンテナから登録済みインターフェーストークンの一覧を取得する
+ * container.tsのinterfaceToKeyMapから動的に取得
+ */
+function getRegisteredInterfaceTokens(): Array<{ token: string; key: string }> {
+  return Object.entries(interfaceToKeyMap).map(([token, key]) => ({ token, key }));
+}
 
 /**
  * DIコンテナのインターフェース登録確認テスト (Awilix)
@@ -69,6 +77,34 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
       expect(typeof resolved).toBe('object');
       expect(resolved.constructor).toBeDefined();
       expect(resolved.constructor.name).toBe(implementationName);
+    });
+  });
+
+  /**
+   * DIコンテナに登録されているインターフェース数と、テストケースで期待する数が一致することを検証
+   * これにより、DIコンテナに新しいインターフェースが追加された場合にテストケースの追加漏れを検出できる
+   */
+  it('DIコンテナ登録数とテストケース数が一致すること', () => {
+    // Act - DIコンテナから登録済みインターフェーストークンを動的取得
+    const actualRegisteredTokens = getRegisteredInterfaceTokens();
+
+    // Assert - 期待される登録数と一致することを確認
+    expect(actualRegisteredTokens).toHaveLength(testCases.length);
+
+    // Assert - 各インターフェースがDIコンテナに登録されていることを確認
+    const actualTokenSet = new Set(actualRegisteredTokens.map(({ token }) => token));
+    testCases.forEach(({ input: { interfaceToken } }) => {
+      expect(actualTokenSet.has(interfaceToken),
+        `Test case exists for ${interfaceToken} but it's not registered in interfaceToKeyMap`
+      ).toBe(true);
+    });
+
+    // Assert - DIコンテナに登録されている各インターフェースにテストケースが存在することを確認
+    const testCaseTokenSet = new Set<string>(testCases.map(tc => tc.input.interfaceToken));
+    actualRegisteredTokens.forEach(({ token }) => {
+      expect(testCaseTokenSet.has(token),
+        `Interface ${token} is registered in interfaceToKeyMap but missing a test case`
+      ).toBe(true);
     });
   });
 });

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -1,4 +1,4 @@
-import { awilixContainer, container } from 'src/infrastructure/di/container';
+import { container } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
 
@@ -11,11 +11,18 @@ function getInterfaceToKeyMap(): Record<string, string> {
 }
 
 /**
+ * containerの内部プロパティからawilixContainerを動的に取得する
+ */
+function getAwilixContainer(): { registrations: Record<string, unknown> } {
+  return (container as any)._awilixContainer;
+}
+
+/**
  * DIコンテナから登録済みインターフェースキーの一覧を取得する
  * awilixContainerのregistrationsから動的に取得し、インターフェース関連のキーのみをフィルタ
  */
 function getRegisteredInterfaceKeys(): string[] {
-  const allKeys = Object.keys(awilixContainer.registrations);
+  const allKeys = Object.keys(getAwilixContainer().registrations);
   const interfaceKeys = Object.values(getInterfaceToKeyMap());
   return allKeys.filter(key => interfaceKeys.includes(key));
 }

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -1,21 +1,10 @@
-import { awilixContainer, container } from 'src/infrastructure/di/container';
+import {
+  awilixContainer,
+  container,
+  interfaceToKeyMap
+} from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
-
-/**
- * インターフェーストークンとAwilix登録キーのマッピング
- * container.tsのinterfaceToKeyMapと同じマッピングを定義
- */
-const interfaceTokenToKeyMap: Record<string, string> = {
-  'IChromeTabsService': 'chromeTabsService',
-  'IPopupService': 'popupService',
-  'IRewriteRuleRepository': 'rewriteRuleRepository',
-  'IWindowService': 'windowService',
-  'ISelectedPageTextRepository': 'selectedPageTextRepository',
-  'ICurrentTabService': 'currentTabService',
-  'IChromeRuntimeService': 'chromeRuntimeService',
-  'IGetSelectionService': 'getSelectionService'
-};
 
 /**
  * DIコンテナから登録済みインターフェースキーの一覧を取得する
@@ -23,7 +12,7 @@ const interfaceTokenToKeyMap: Record<string, string> = {
  */
 function getRegisteredInterfaceKeys(): string[] {
   const allKeys = Object.keys(awilixContainer.registrations);
-  const interfaceKeys = Object.values(interfaceTokenToKeyMap);
+  const interfaceKeys = Object.values(interfaceToKeyMap);
   return allKeys.filter(key => interfaceKeys.includes(key));
 }
 
@@ -111,7 +100,7 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
     // Assert - 各テストケースのインターフェースがDIコンテナに登録されていることを確認
     const actualKeySet = new Set(actualRegisteredKeys);
     testCases.forEach(({ input: { interfaceToken } }) => {
-      const expectedKey = interfaceTokenToKeyMap[interfaceToken];
+      const expectedKey = interfaceToKeyMap[interfaceToken];
       expect(actualKeySet.has(expectedKey),
         `Test case exists for ${interfaceToken} but key '${expectedKey}' is not registered in awilixContainer`
       ).toBe(true);
@@ -119,7 +108,7 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
 
     // Assert - DIコンテナに登録されている各インターフェースキーにテストケースが存在することを確認
     const testCaseKeySet = new Set<string>(
-      testCases.map(tc => interfaceTokenToKeyMap[tc.input.interfaceToken])
+      testCases.map(tc => interfaceToKeyMap[tc.input.interfaceToken])
     );
     actualRegisteredKeys.forEach((key) => {
       expect(testCaseKeySet.has(key),

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -1,10 +1,14 @@
-import {
-  awilixContainer,
-  container,
-  interfaceToKeyMap
-} from 'src/infrastructure/di/container';
+import { awilixContainer, container } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
+
+/**
+ * containerの内部プロパティからinterfaceToKeyMapを動的に取得する
+ * tsyringeの_registry._registryMapと同様のアクセスパターン
+ */
+function getInterfaceToKeyMap(): Record<string, string> {
+  return (container as any)._interfaceToKeyMap;
+}
 
 /**
  * DIコンテナから登録済みインターフェースキーの一覧を取得する
@@ -12,7 +16,7 @@ import { describe, expect, it } from 'vitest';
  */
 function getRegisteredInterfaceKeys(): string[] {
   const allKeys = Object.keys(awilixContainer.registrations);
-  const interfaceKeys = Object.values(interfaceToKeyMap);
+  const interfaceKeys = Object.values(getInterfaceToKeyMap());
   return allKeys.filter(key => interfaceKeys.includes(key));
 }
 
@@ -98,9 +102,10 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
     expect(actualRegisteredKeys).toHaveLength(testCases.length);
 
     // Assert - 各テストケースのインターフェースがDIコンテナに登録されていることを確認
+    const interfaceMapping = getInterfaceToKeyMap();
     const actualKeySet = new Set(actualRegisteredKeys);
     testCases.forEach(({ input: { interfaceToken } }) => {
-      const expectedKey = interfaceToKeyMap[interfaceToken];
+      const expectedKey = interfaceMapping[interfaceToken];
       expect(actualKeySet.has(expectedKey),
         `Test case exists for ${interfaceToken} but key '${expectedKey}' is not registered in awilixContainer`
       ).toBe(true);
@@ -108,7 +113,7 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
 
     // Assert - DIコンテナに登録されている各インターフェースキーにテストケースが存在することを確認
     const testCaseKeySet = new Set<string>(
-      testCases.map(tc => interfaceToKeyMap[tc.input.interfaceToken])
+      testCases.map(tc => interfaceMapping[tc.input.interfaceToken])
     );
     actualRegisteredKeys.forEach((key) => {
       expect(testCaseKeySet.has(key),

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -1,13 +1,30 @@
-import { container, interfaceToKeyMap } from 'src/infrastructure/di/container';
+import { awilixContainer, container } from 'src/infrastructure/di/container';
 
 import { describe, expect, it } from 'vitest';
 
 /**
- * DIコンテナから登録済みインターフェーストークンの一覧を取得する
- * container.tsのinterfaceToKeyMapから動的に取得
+ * インターフェーストークンとAwilix登録キーのマッピング
+ * container.tsのinterfaceToKeyMapと同じマッピングを定義
  */
-function getRegisteredInterfaceTokens(): Array<{ token: string; key: string }> {
-  return Object.entries(interfaceToKeyMap).map(([token, key]) => ({ token, key }));
+const interfaceTokenToKeyMap: Record<string, string> = {
+  'IChromeTabsService': 'chromeTabsService',
+  'IPopupService': 'popupService',
+  'IRewriteRuleRepository': 'rewriteRuleRepository',
+  'IWindowService': 'windowService',
+  'ISelectedPageTextRepository': 'selectedPageTextRepository',
+  'ICurrentTabService': 'currentTabService',
+  'IChromeRuntimeService': 'chromeRuntimeService',
+  'IGetSelectionService': 'getSelectionService'
+};
+
+/**
+ * DIコンテナから登録済みインターフェースキーの一覧を取得する
+ * awilixContainerのregistrationsから動的に取得し、インターフェース関連のキーのみをフィルタ
+ */
+function getRegisteredInterfaceKeys(): string[] {
+  const allKeys = Object.keys(awilixContainer.registrations);
+  const interfaceKeys = Object.values(interfaceTokenToKeyMap);
+  return allKeys.filter(key => interfaceKeys.includes(key));
 }
 
 /**
@@ -85,25 +102,28 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
    * これにより、DIコンテナに新しいインターフェースが追加された場合にテストケースの追加漏れを検出できる
    */
   it('DIコンテナ登録数とテストケース数が一致すること', () => {
-    // Act - DIコンテナから登録済みインターフェーストークンを動的取得
-    const actualRegisteredTokens = getRegisteredInterfaceTokens();
+    // Act - DIコンテナから登録済みインターフェースキーを動的取得
+    const actualRegisteredKeys = getRegisteredInterfaceKeys();
 
     // Assert - 期待される登録数と一致することを確認
-    expect(actualRegisteredTokens).toHaveLength(testCases.length);
+    expect(actualRegisteredKeys).toHaveLength(testCases.length);
 
-    // Assert - 各インターフェースがDIコンテナに登録されていることを確認
-    const actualTokenSet = new Set(actualRegisteredTokens.map(({ token }) => token));
+    // Assert - 各テストケースのインターフェースがDIコンテナに登録されていることを確認
+    const actualKeySet = new Set(actualRegisteredKeys);
     testCases.forEach(({ input: { interfaceToken } }) => {
-      expect(actualTokenSet.has(interfaceToken),
-        `Test case exists for ${interfaceToken} but it's not registered in interfaceToKeyMap`
+      const expectedKey = interfaceTokenToKeyMap[interfaceToken];
+      expect(actualKeySet.has(expectedKey),
+        `Test case exists for ${interfaceToken} but key '${expectedKey}' is not registered in awilixContainer`
       ).toBe(true);
     });
 
-    // Assert - DIコンテナに登録されている各インターフェースにテストケースが存在することを確認
-    const testCaseTokenSet = new Set<string>(testCases.map(tc => tc.input.interfaceToken));
-    actualRegisteredTokens.forEach(({ token }) => {
-      expect(testCaseTokenSet.has(token),
-        `Interface ${token} is registered in interfaceToKeyMap but missing a test case`
+    // Assert - DIコンテナに登録されている各インターフェースキーにテストケースが存在することを確認
+    const testCaseKeySet = new Set<string>(
+      testCases.map(tc => interfaceTokenToKeyMap[tc.input.interfaceToken])
+    );
+    actualRegisteredKeys.forEach((key) => {
+      expect(testCaseKeySet.has(key),
+        `Key '${key}' is registered in awilixContainer but missing a test case`
       ).toBe(true);
     });
   });


### PR DESCRIPTION
- Export interfaceToKeyMap from container.ts for test access
- Add helper function getRegisteredInterfaceTokens() to dynamically retrieve registered interface tokens
- Add test case to verify that:
  - Number of registered interfaces matches test cases
  - Every test case corresponds to a registered interface
  - Every registered interface has a corresponding test case

This mirrors the pattern from PR #212 for concrete class registration tests, ensuring test completeness for interface registrations.