### PR TITLE
Add tests for contentContainer dependency injection

### DIFF
--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
@@ -97,9 +97,6 @@ const classToKeyMap = new Map<Function, keyof ContentContainerCradle>([
   [DomRootChecker, 'domRootChecker']
 ]);
 
-// Export interfaceToKeyMap for testing
-export { interfaceToKeyMap };
-
 // Container interface with overloaded resolve
 interface ContentContainer {
   resolve(token: typeof ApplyRulesOnDomMutationUseCase): ApplyRulesOnDomMutationUseCase;

--- a/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/di/contentContainer.ts
@@ -68,6 +68,24 @@ interface ContentContainerCradle {
   getElementSelectionUseCase: GetElementSelectionUseCase;
 }
 
+// Token mappings for interface-based resolution
+type InterfaceToken =
+  | 'IRewriteRuleRepository'
+  | 'ICurrentUrlService'
+  | 'IDebounceTimer'
+  | 'IObserverControl'
+  | 'IGetSelectionService'
+  | 'IDomRootChecker';
+
+const interfaceToKeyMap: Record<InterfaceToken, keyof ContentContainerCradle> = {
+  'IRewriteRuleRepository': 'chromeRuntimeRewriteRuleRepository',
+  'ICurrentUrlService': 'windowCurrentUrlService',
+  'IDebounceTimer': 'debounceTimer',
+  'IObserverControl': 'observerControl',
+  'IGetSelectionService': 'getSelectionService',
+  'IDomRootChecker': 'domRootChecker'
+};
+
 // Class to key mappings for class-based resolution
 const classToKeyMap = new Map<Function, keyof ContentContainerCradle>([
   [ApplyRulesOnDomMutationUseCase, 'applyRulesOnDomMutationUseCase'],
@@ -79,6 +97,9 @@ const classToKeyMap = new Map<Function, keyof ContentContainerCradle>([
   [DomRootChecker, 'domRootChecker']
 ]);
 
+// Export interfaceToKeyMap for testing
+export { interfaceToKeyMap };
+
 // Container interface with overloaded resolve
 interface ContentContainer {
   resolve(token: typeof ApplyRulesOnDomMutationUseCase): ApplyRulesOnDomMutationUseCase;
@@ -88,12 +109,23 @@ interface ContentContainer {
   resolve(token: typeof DebounceTimer): DebounceTimer;
   resolve(token: typeof GetSelectionService): GetSelectionService;
   resolve(token: typeof DomRootChecker): DomRootChecker;
+  resolve<T>(token: InterfaceToken): T;
   resolve<T>(token: Function): T;
 }
 
 // Wrapper to provide container API
 export const contentContainer: ContentContainer = {
-  resolve(token: Function): any {
+  resolve(token: InterfaceToken | Function): any {
+    // Interface token resolution
+    if (typeof token === 'string') {
+      const key = interfaceToKeyMap[token as InterfaceToken];
+      if (!key) {
+        throw new Error(`Unknown interface token: ${token}`);
+      }
+      return awilixContainer.resolve(key);
+    }
+
+    // Class-based resolution
     const key = classToKeyMap.get(token);
     if (!key) {
       throw new Error(`Unknown class token: ${(token as any).name}`);
@@ -101,3 +133,8 @@ export const contentContainer: ContentContainer = {
     return awilixContainer.resolve(key);
   }
 };
+
+// Attach internal data for test introspection (similar to tsyringe's _registry)
+(contentContainer as any)._interfaceToKeyMap = interfaceToKeyMap;
+(contentContainer as any)._classToKeyMap = classToKeyMap;
+(contentContainer as any)._awilixContainer = awilixContainer;

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/concrete-class-registration-completeness.test.ts
@@ -6,7 +6,24 @@ import { ChromeRuntimeRewriteRuleRepository } from 'src/infrastructure/browser/m
 import { DebounceTimer } from 'src/infrastructure/browser/timer/DebounceTimer';
 import { WindowCurrentUrlService } from 'src/infrastructure/browser/window/WindowCurrentUrlService';
 import { contentContainer } from 'src/infrastructure/di/contentContainer';
+import { DomRootChecker } from 'src/infrastructure/document/DomRootChecker';
 import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
+
+/**
+ * contentContainerの内部プロパティからclassToKeyMapを動的に取得する
+ * tsyringeの_registry._registryMapと同様のアクセスパターン
+ */
+function getClassToKeyMap(): Map<Function, string> {
+  return (contentContainer as any)._classToKeyMap;
+}
+
+/**
+ * DIコンテナから登録済み具体クラストークンの一覧を取得する
+ * contentContainer.tsのclassToKeyMapから動的に取得
+ */
+function getRegisteredConcreteClassTokens(): Array<{ token: Function; key: string }> {
+  return Array.from(getClassToKeyMap().entries()).map(([token, key]) => ({ token, key }));
+}
 
 /**
  * Content Script用DIコンテナの具体クラス登録確認テスト (Awilix)
@@ -47,6 +64,11 @@ describe('Content DI Container - 具体クラス登録確認テスト (Awilix)',
       description: 'GetSelectionServiceを解決できること',
       input: { classToken: GetSelectionService },
       expected: { className: 'GetSelectionService' }
+    },
+    {
+      description: 'DomRootCheckerを解決できること',
+      input: { classToken: DomRootChecker },
+      expected: { className: 'DomRootChecker' }
     }
   ];
 
@@ -64,6 +86,34 @@ describe('Content DI Container - 具体クラス登録確認テスト (Awilix)',
       expect(resolved).not.toBeNull();
       expect(resolved).toBeInstanceOf(classToken);
       expect((resolved as any).constructor.name).toBe(className);
+    });
+  });
+
+  /**
+   * DIコンテナに登録されている具体クラス数と、テストケースで期待する数が一致することを検証
+   * これにより、DIコンテナに新しいクラスが追加された場合にテストケースの追加漏れを検出できる
+   */
+  it('DIコンテナ登録数とテストケース数が一致すること', () => {
+    // Act - DIコンテナから登録済み具体クラストークンを動的取得
+    const actualRegisteredTokens = getRegisteredConcreteClassTokens();
+
+    // Assert - 期待される登録数と一致することを確認
+    expect(actualRegisteredTokens).toHaveLength(testCases.length);
+
+    // Assert - 各具体クラスがDIコンテナに登録されていることを確認
+    const actualTokenSet = new Set(actualRegisteredTokens.map(({ token }) => token));
+    testCases.forEach(({ input: { classToken } }) => {
+      expect(actualTokenSet.has(classToken),
+        `Test case exists for ${classToken.name} but it's not registered in classToKeyMap`
+      ).toBe(true);
+    });
+
+    // Assert - DIコンテナに登録されている各クラスにテストケースが存在することを確認
+    const testCaseTokenSet = new Set<Function>(testCases.map(tc => tc.input.classToken));
+    actualRegisteredTokens.forEach(({ token }) => {
+      expect(testCaseTokenSet.has(token),
+        `Class ${(token as any).name} is registered in classToKeyMap but missing a test case`
+      ).toBe(true);
     });
   });
 });

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/contentContainer/interface-registration-completeness.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { contentContainer } from 'src/infrastructure/di/contentContainer';
+
+/**
+ * contentContainerの内部プロパティからinterfaceToKeyMapを動的に取得する
+ * tsyringeの_registry._registryMapと同様のアクセスパターン
+ */
+function getInterfaceToKeyMap(): Record<string, string> {
+  return (contentContainer as any)._interfaceToKeyMap;
+}
+
+/**
+ * contentContainerの内部プロパティからawilixContainerを動的に取得する
+ */
+function getAwilixContainer(): { registrations: Record<string, unknown> } {
+  return (contentContainer as any)._awilixContainer;
+}
+
+/**
+ * DIコンテナから登録済みインターフェースキーの一覧を取得する
+ * awilixContainerのregistrationsから動的に取得し、インターフェース関連のキーのみをフィルタ
+ */
+function getRegisteredInterfaceKeys(): string[] {
+  const allKeys = Object.keys(getAwilixContainer().registrations);
+  const interfaceKeys = Object.values(getInterfaceToKeyMap());
+  return allKeys.filter(key => interfaceKeys.includes(key));
+}
+
+/**
+ * Content Script用DIコンテナのインターフェース登録確認テスト (Awilix)
+ * contentContainer.resolve()でインターフェーストークンを解決できることを検証する
+ */
+describe('Content DI Container - インターフェース登録確認テスト (Awilix)', () => {
+  /**
+   * インターフェース解決テストケース
+   * 各インターフェーストークンが正しい実装クラスに解決されることを検証する
+   */
+  const testCases = [
+    {
+      description: 'IRewriteRuleRepositoryをChromeRuntimeRewriteRuleRepositoryに解決できること',
+      input: { interfaceToken: 'IRewriteRuleRepository' as const },
+      expected: { implementationName: 'ChromeRuntimeRewriteRuleRepository' }
+    },
+    {
+      description: 'ICurrentUrlServiceをWindowCurrentUrlServiceに解決できること',
+      input: { interfaceToken: 'ICurrentUrlService' as const },
+      expected: { implementationName: 'WindowCurrentUrlService' }
+    },
+    {
+      description: 'IDebounceTimerをDebounceTimerに解決できること',
+      input: { interfaceToken: 'IDebounceTimer' as const },
+      expected: { implementationName: 'DebounceTimer' }
+    },
+    {
+      description: 'IObserverControlをobserverControlに解決できること',
+      input: { interfaceToken: 'IObserverControl' as const },
+      expected: { implementationName: 'Object' }
+    },
+    {
+      description: 'IGetSelectionServiceをGetSelectionServiceに解決できること',
+      input: { interfaceToken: 'IGetSelectionService' as const },
+      expected: { implementationName: 'GetSelectionService' }
+    },
+    {
+      description: 'IDomRootCheckerをDomRootCheckerに解決できること',
+      input: { interfaceToken: 'IDomRootChecker' as const },
+      expected: { implementationName: 'DomRootChecker' }
+    }
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, () => {
+      // Arrange
+      const { interfaceToken } = testCase.input;
+      const { implementationName } = testCase.expected;
+
+      // Act
+      const resolved = contentContainer.resolve(interfaceToken) as any;
+
+      // Assert
+      expect(resolved).toBeDefined();
+      expect(resolved).not.toBeNull();
+      expect(typeof resolved).toBe('object');
+      expect(resolved.constructor).toBeDefined();
+      expect(resolved.constructor.name).toBe(implementationName);
+    });
+  });
+
+  /**
+   * DIコンテナに登録されているインターフェース数と、テストケースで期待する数が一致することを検証
+   * これにより、DIコンテナに新しいインターフェースが追加された場合にテストケースの追加漏れを検出できる
+   */
+  it('DIコンテナ登録数とテストケース数が一致すること', () => {
+    // Act - DIコンテナから登録済みインターフェースキーを動的取得
+    const actualRegisteredKeys = getRegisteredInterfaceKeys();
+
+    // Assert - 期待される登録数と一致することを確認
+    expect(actualRegisteredKeys).toHaveLength(testCases.length);
+
+    // Assert - 各テストケースのインターフェースがDIコンテナに登録されていることを確認
+    const interfaceMapping = getInterfaceToKeyMap();
+    const actualKeySet = new Set(actualRegisteredKeys);
+    testCases.forEach(({ input: { interfaceToken } }) => {
+      const expectedKey = interfaceMapping[interfaceToken];
+      expect(actualKeySet.has(expectedKey),
+        `Test case exists for ${interfaceToken} but key '${expectedKey}' is not registered in awilixContainer`
+      ).toBe(true);
+    });
+
+    // Assert - DIコンテナに登録されている各インターフェースキーにテストケースが存在することを確認
+    const testCaseKeySet = new Set<string>(
+      testCases.map(tc => interfaceMapping[tc.input.interfaceToken])
+    );
+    actualRegisteredKeys.forEach((key) => {
+      expect(testCaseKeySet.has(key),
+        `Key '${key}' is registered in awilixContainer but missing a test case`
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
- Add interfaceToKeyMap and internal property exposure to contentContainer.ts
- Add registration count matching test to concrete-class-registration-completeness.test.ts
- Add DomRootChecker to concrete class test cases
- Create interface-registration-completeness.test.ts with same pattern as container.ts tests