### PR TITLE
Resolve easiest TODO comment in codebase

### DIFF
--- a/host-frontend-root/frontend-src-root/tests/unit/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase/handleMutations/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase/handleMutations/normal-cases.test.ts
@@ -1,11 +1,9 @@
+import { createMockDomRootChecker } from 'tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker';
 import { createMockElementFactory } from 'tests/unit/domain/ports/IElementFactory/createMockElementFactory';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApplyRulesOnDomMutationUseCase } from 'src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase';
 
-/**
- * TODO: モックはcreateMockクラスに切り出す
- */
 const mockElementFactory = createMockElementFactory();
 
 /**
@@ -53,11 +51,7 @@ describe('ApplyRulesOnDomMutationUseCase.handleMutations - 正常系', () => {
       disconnect: vi.fn(),
       reconnect: vi.fn(),
     };
-    // TODO: mockDomRootCheckerを他のmockを参考に切り出す
-    mockDomRootChecker = {
-      isDocumentRoot: vi.fn().mockReturnValue(false),
-      isAttachedToDocument: vi.fn().mockImplementation((element: Element) => attachedElements.has(element)),
-    };
+    mockDomRootChecker = createMockDomRootChecker(attachedElements);
 
     // UseCaseを作成し、applyRulesToRootを呼び出して初回ロード完了状態にする
     useCase = new ApplyRulesOnDomMutationUseCase(

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker.ts
@@ -1,0 +1,13 @@
+import type { IDomRootChecker } from 'src/domain/ports/IDomRootChecker';
+
+/**
+ * テスト用のモックDomRootCheckerを作成
+ * @param attachedElements ドキュメントに接続されている要素のSet
+ * @returns IDomRootCheckerのモック実装
+ */
+export function createMockDomRootChecker(attachedElements: Set<Element>): IDomRootChecker {
+  return {
+    isDocumentRoot: () => false,
+    isAttachedToDocument: (element: Element) => attachedElements.has(element)
+  };
+}

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Elements/extractAttachedElements/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Elements/extractAttachedElements/normal-cases.test.ts
@@ -1,6 +1,6 @@
+import { createMockDomRootChecker } from 'tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker';
 import { describe, expect, it } from 'vitest';
 
-import { IDomRootChecker } from 'src/domain/ports/IDomRootChecker';
 import { Elements } from 'src/domain/value-objects/Elements/Elements';
 import { MutationRecords } from 'src/domain/value-objects/MutationRecords/MutationRecords';
 
@@ -13,10 +13,6 @@ import { MutationRecords } from 'src/domain/value-objects/MutationRecords/Mutati
  * 4. document.bodyに存在しない要素は除外する
  */
 describe('Elements.extractAttachedElements - 正常系', () => {
-  const createMockDomRootChecker = (attachedElements: Set<Element>): IDomRootChecker => ({
-    isDocumentRoot: () => false,
-    isAttachedToDocument: (element: Element) => attachedElements.has(element)
-  });
 
   it('should return collected elements that are in document body', () => {
     // Arrange

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Elements/merge/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Elements/merge/normal-cases.test.ts
@@ -1,6 +1,6 @@
+import { createMockDomRootChecker } from 'tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker';
 import { describe, expect, it } from 'vitest';
 
-import { IDomRootChecker } from 'src/domain/ports/IDomRootChecker';
 import { Elements } from 'src/domain/value-objects/Elements/Elements';
 import { MutationRecords } from 'src/domain/value-objects/MutationRecords/MutationRecords';
 
@@ -13,10 +13,6 @@ import { MutationRecords } from 'src/domain/value-objects/MutationRecords/Mutati
  * 4. 重複する要素は1つにまとめる
  */
 describe('Elements.merge - 正常系', () => {
-  const createMockDomRootChecker = (attachedElements: Set<Element>): IDomRootChecker => ({
-    isDocumentRoot: () => false,
-    isAttachedToDocument: (element: Element) => attachedElements.has(element)
-  });
 
   it('should merge Elements from MutationRecords', () => {
     // Arrange


### PR DESCRIPTION
TODOコメントを解決するため、重複していたmockDomRootCheckerを
tests/unit/domain/ports/IDomRootChecker/createMockDomRootChecker.ts に共通ファクトリとして切り出しました。