### PR TITLE
Add missing workflow documentation

### DIFF
--- a/.claude/commands/workflow-after-coding-record-progress.md
+++ b/.claude/commands/workflow-after-coding-record-progress.md
@@ -1,0 +1,5 @@
+# workflow-after-coding-record-progress
+
+**FIRST**, YOU MUST READ FOLLOWING REFERENCE FILE TO UNDERSTAND THE CONTEXT AND DISPLAY ALL OF THE SENTENCES IN THAT FILE.
+
+Reference: `.clinerules/02-workflow-automation/03-daily-scrum-finishes/workflow-after-coding-record-progress.md`

--- a/.claude/commands/workflow-record-progress-after-coding.md
+++ b/.claude/commands/workflow-record-progress-after-coding.md
@@ -1,5 +1,0 @@
-# workflow-record-progress-after-coding
-
-**FIRST**, YOU MUST READ FOLLOWING REFERENCE FILE TO UNDERSTAND THE CONTEXT AND DISPLAY ALL OF THE SENTENCES IN THAT FILE.
-
-Reference: `.clinerules/02-workflow-automation/03-daily-scrum-finishes/workflow-record-progress-after-coding.md`


### PR DESCRIPTION
.claude/commandsのファイル名を.clinerules側のファイル名と一致させ、
参照パスを正しいパスに修正