### PR TITLE
Resolve easiest TODO comment in codebase

### DIFF
--- a/host-frontend-root/frontend-src-root/src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase.ts
+++ b/host-frontend-root/frontend-src-root/src/application/usecases/contentOnMessageReceived/ApplyRulesOnDomMutationUseCase.ts
@@ -35,7 +35,6 @@ export class ApplyRulesOnDomMutationUseCase {
   private hasInitialLoadCompleted: boolean;
   private isApplyingToRoot: boolean;
 
-  // TODO: このconstructorをDIで解決する
   constructor(
     repository: IRewriteRuleRepository,
     currentUrlService: ICurrentUrlService,


### PR DESCRIPTION
ApplyRulesOnDomMutationUseCaseのコンストラクタにあった
「このconstructorをDIで解決する」というTODOは、contentContainer.tsで 既に実装済みのため、コメントを削除