### PR TITLE
Resolve merge conflicts in PR 230

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ These wrapper functions provide shorter alternatives to `make wt-add BRANCH=...`
 **Shell Function Setup (Required for navigation and wrapper commands):**
 Add to your `~/.bashrc` or `~/.zshrc`:
 ```bash
-source /path/to/frog-frame-front/scripts/wt-cd.sh
+source /path/to/frog-frame-front/scripts/main.sh
 ```
 
 **Recommended Worktree Workflow:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,16 @@ wt-cd feature-x                 # Navigate to specific worktree
 wt-cd-current                   # Navigate to current worktree
 ```
 
-**Shell Function Setup (Required for navigation commands):**
+**Shell Wrapper Commands with Tab Completion (requires shell function setup):**
+```bash
+wt-add feature-x                # Create worktree (Tab completes all branches)
+wt-remove feature-x             # Remove worktree (Tab completes existing worktrees)
+wt-dev feature-x                # Start dev server (Tab completes existing worktrees)
+```
+
+These wrapper functions provide shorter alternatives to `make wt-add BRANCH=...` commands with Tab completion support for both Bash and Zsh.
+
+**Shell Function Setup (Required for navigation and wrapper commands):**
 Add to your `~/.bashrc` or `~/.zshrc`:
 ```bash
 source /path/to/frog-frame-front/scripts/wt-cd.sh

--- a/docs/GIT_WORKTREE.md
+++ b/docs/GIT_WORKTREE.md
@@ -8,7 +8,7 @@ Git worktreeは、同じリポジトリの複数のブランチを同時にチ�
 
 ```bash
 # ~/.bashrcまたは~/.zshrcに追加
-source /path/to/frog-frame-front/scripts/wt-cd.sh
+source /path/to/frog-frame-front/scripts/main.sh
 ```
 
 これにより以下のコマンドが使用可能になります：
@@ -277,7 +277,7 @@ make wt-remove BRANCH=your-branch
 
 ### シェルラッパーコマンド（Tab補完対応）
 
-シェル関数設定後（`source scripts/wt-cd.sh`）に使用可能。
+シェル関数設定後（`source scripts/main.sh`）に使用可能。
 
 | コマンド | 説明 | Tab補完対象 |
 |---------|------|-------------|

--- a/docs/GIT_WORKTREE.md
+++ b/docs/GIT_WORKTREE.md
@@ -12,8 +12,43 @@ source /path/to/frog-frame-front/scripts/wt-cd.sh
 ```
 
 これにより以下のコマンドが使用可能になります：
+
+### ナビゲーションコマンド
 - `wt-cd <branch>` - 指定したworktreeディレクトリに移動
 - `wt-cd-current` - 現在のworktreeディレクトリに移動（内部で`wt-cd`を使用）
+
+### シェルラッパーコマンド（Tab補完対応）
+
+`make`コマンドの短縮版として、以下のシェル関数が使用できます。**BashとZsh両方でTab補完が有効**です。
+
+| コマンド | 説明 | Tab補完対象 |
+|---------|------|-------------|
+| `wt-add <branch>` | worktree作成 | 全ブランチ（ローカル/リモート） |
+| `wt-remove <branch>` | worktree削除 | 既存worktree |
+| `wt-dev <branch>` | 開発サーバー起動 | 既存worktree |
+
+#### 使用例
+
+```bash
+# Tab補完でブランチを選択してworktree作成
+wt-add feat<TAB>  # → wt-add feature-branch
+
+# Tab補完で既存worktreeを選択して開発開始
+wt-dev feat<TAB>  # → wt-dev feature-branch
+
+# Tab補完で既存worktreeを選択して削除
+wt-remove feat<TAB>  # → wt-remove feature-branch
+```
+
+#### makeコマンドとの対応
+
+| シェルラッパー | 対応するmakeコマンド |
+|---------------|---------------------|
+| `wt-add feature-x` | `make wt-add BRANCH=feature-x` |
+| `wt-remove feature-x` | `make wt-remove BRANCH=feature-x` |
+| `wt-dev feature-x` | `make wt-dev BRANCH=feature-x` |
+
+Tab補完により、長いブランチ名を入力する手間が省けます。
 
 ## 利点
 
@@ -102,7 +137,7 @@ make wt-up
 
 注：これらのコマンドは`.env.worktree`の設定を使用します。
 
-### ナビゲーションコマンド
+### ナビゲーション・シェルラッパーコマンド
 
 #### 現在のworktree確認
 
@@ -111,11 +146,21 @@ make wt-up
 make wt-current
 ```
 
-#### worktreeディレクトリへ移動
+#### シェルラッパーコマンド（Tab補完対応）
 
 シェル関数の設定が必要です（「シェル関数の設定」セクション参照）。
 
 ```bash
+# Tab補完でブランチを選択してworktree作成
+wt-add feature-branch
+
+# Tab補完で既存worktreeを選択して開発開始
+wt-dev feature-branch
+
+# Tab補完で既存worktreeを選択して削除
+wt-remove feature-branch
+
+# worktreeディレクトリへ移動
 wt-cd feature-branch  # 特定のworktreeへ移動
 wt-cd-current         # 現在のworktreeへ移動
 ```
@@ -216,6 +261,8 @@ make wt-remove BRANCH=your-branch
 
 ## コマンドリファレンス
 
+### Makeコマンド
+
 | コマンド | 説明 | 使用例 |
 |---------|------|--------|
 | `wt-list` | すべてのworktreeを一覧表示 | `make wt-list` |
@@ -227,6 +274,18 @@ make wt-remove BRANCH=your-branch
 | `wt-disable` | worktreeモードを無効化、メインリポジトリに戻る | `make wt-disable` |
 | `wt-down` | worktreeのDockerコンテナを停止 | `make wt-down` |
 | `wt-up` | worktreeのDockerコンテナを起動 | `make wt-up` |
+
+### シェルラッパーコマンド（Tab補完対応）
+
+シェル関数設定後（`source scripts/wt-cd.sh`）に使用可能。
+
+| コマンド | 説明 | Tab補完対象 |
+|---------|------|-------------|
+| `wt-add <branch>` | worktree作成 | 全ブランチ（ローカル/リモート） |
+| `wt-remove <branch>` | worktree削除 | 既存worktree |
+| `wt-dev <branch>` | 開発サーバー起動 | 既存worktree |
+| `wt-cd <branch>` | worktreeディレクトリへ移動 | 既存worktree |
+| `wt-cd-current` | 現在のworktreeへ移動 | - |
 
 ## 直接gitコマンドを使用する場合
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Main entry point for frog-frame-front shell functions
+# Add this to your shell profile: source /path/to/frog-frame-front/scripts/main.sh
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source all shell function scripts
+source "$SCRIPT_DIR/wt-cd.sh"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -7,4 +7,4 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source all shell function scripts
-source "$SCRIPT_DIR/wt-cd.sh"
+source "$SCRIPT_DIR/worktree/main.sh"

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Bash completion for worktree commands
+# This file is sourced by scripts/worktree/main.sh
+
+# Completion for wt-add (all branches)
+_wt_add_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "$(_wt_get_all_branches)" -- "$cur"))
+}
+complete -F _wt_add_completion wt-add
+
+# Completion for wt-remove (existing worktrees)
+_wt_remove_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+}
+complete -F _wt_remove_completion wt-remove
+
+# Completion for wt-dev (existing worktrees)
+_wt_dev_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+}
+complete -F _wt_dev_completion wt-dev
+
+# Completion for wt-cd (existing worktrees)
+_wt_cd_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+}
+complete -F _wt_cd_completion wt-cd

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -10,6 +10,25 @@ _wt_get_completion_function_name() {
     echo "_${command_name//-/_}_completion"
 }
 
+# Define a completion function dynamically
+# Example: _wt_define_completion_function "_wt_add_completion" "_wt_get_all_branches"
+_wt_define_completion_function() {
+    local completion_function_name="$1"
+    local source_function_name="$2"
+    eval "$completion_function_name() {
+        local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
+        COMPREPLY=(\$(compgen -W \"\$($source_function_name)\" -- \"\$cur\"))
+    }"
+}
+
+# Register completion function for a command
+# Example: _wt_register_completion "_wt_add_completion" "wt-add"
+_wt_register_completion() {
+    local completion_function_name="$1"
+    local command_name="$2"
+    complete -F "$completion_function_name" "$command_name"
+}
+
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for definition in "${_WT_COMPLETION_DEFS[@]}"; do
@@ -25,14 +44,7 @@ for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add" -> "_wt_add_completion"
     completion_function_name="$(_wt_get_completion_function_name "$command_name")"
 
-    # Create completion function dynamically
-    # The function calls $source_function_name to get completion candidates
-    eval "$completion_function_name() {
-        local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
-        COMPREPLY=(\$(compgen -W \"\$($source_function_name)\" -- \"\$cur\"))
-    }"
-
-    # Register the completion function for the command
-    # Example: complete -F _wt_add_completion wt-add
-    complete -F "$completion_function_name" "$command_name"
+    # Create and register completion function
+    _wt_define_completion_function "$completion_function_name" "$source_function_name"
+    _wt_register_completion "$completion_function_name" "$command_name"
 done

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -3,6 +3,13 @@
 # Bash completion for worktree commands
 # This file is sourced by scripts/worktree/branch-completion/main.sh
 
+# Generate completion function name for Bash
+# Example: "wt-add" -> "_wt_add_completion"
+_wt_get_completion_function_name() {
+    local command_name="$1"
+    echo "_${command_name//-/_}_completion"
+}
+
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for definition in "${_WT_COMPLETION_DEFS[@]}"; do

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -6,15 +6,18 @@
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
-    # Extract command name from definition
+    # Extract command name from definition using parameter expansion
+    # ${var%%pattern} removes longest match of pattern from the end
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
     cmd="${def%%=*}"
 
-    # Extract source function name from definition
+    # Extract source function name from definition using parameter expansion
+    # ${var#pattern} removes shortest match of pattern from the beginning
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
     # Create completion function dynamically
+    # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
     # Example: For cmd="wt-add", creates function "_wt_add_completion"
     # The function calls $source_fn to get completion candidates
     eval "_${cmd//-/_}_completion() {

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -6,15 +6,13 @@
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
-    # Extract command name from definition using parameter expansion
-    # ${var%%pattern} removes longest match of pattern from the end
+    # Extract command name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
-    cmd="${def%%=*}"
+    cmd="$(_wt_get_command_name "$def")"
 
-    # Extract source function name from definition using parameter expansion
-    # ${var#pattern} removes shortest match of pattern from the beginning
+    # Extract source function name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
-    source_fn="${def#*=}"
+    source_fn="$(_wt_get_source_function_name "$def")"
 
     # Generate completion function name
     # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -1,32 +1,19 @@
 #!/bin/bash
 
 # Bash completion for worktree commands
-# This file is sourced by scripts/worktree/main.sh
+# This file is sourced by scripts/worktree/branch-completion/main.sh
 
-# Completion for wt-add (all branches)
-_wt_add_completion() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=($(compgen -W "$(_wt_get_all_branches)" -- "$cur"))
-}
-complete -F _wt_add_completion wt-add
+# Register completions from _WT_COMPLETION_DEFS
+for def in "${_WT_COMPLETION_DEFS[@]}"; do
+    cmd="${def%%=*}"
+    source_fn="${def#*=}"
 
-# Completion for wt-remove (existing worktrees)
-_wt_remove_completion() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-}
-complete -F _wt_remove_completion wt-remove
+    # Create completion function dynamically
+    eval "_${cmd//-/_}_completion() {
+        local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
+        COMPREPLY=(\$(compgen -W \"\$($source_fn)\" -- \"\$cur\"))
+    }"
 
-# Completion for wt-dev (existing worktrees)
-_wt_dev_completion() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-}
-complete -F _wt_dev_completion wt-dev
-
-# Completion for wt-cd (existing worktrees)
-_wt_cd_completion() {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-}
-complete -F _wt_cd_completion wt-cd
+    # Register the completion
+    complete -F "_${cmd//-/_}_completion" "$cmd"
+done

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -16,16 +16,19 @@ for def in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
-    # Create completion function dynamically
+    # Generate completion function name
     # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
-    # Example: For cmd="wt-add", creates function "_wt_add_completion"
+    # Example: "wt-add" -> "_wt_add_completion"
+    completion_fn="_${cmd//-/_}_completion"
+
+    # Create completion function dynamically
     # The function calls $source_fn to get completion candidates
-    eval "_${cmd//-/_}_completion() {
+    eval "$completion_fn() {
         local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
         COMPREPLY=(\$(compgen -W \"\$($source_fn)\" -- \"\$cur\"))
     }"
 
     # Register the completion function for the command
     # Example: complete -F _wt_add_completion wt-add
-    complete -F "_${cmd//-/_}_completion" "$cmd"
+    complete -F "$completion_fn" "$cmd"
 done

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -4,16 +4,25 @@
 # This file is sourced by scripts/worktree/branch-completion/main.sh
 
 # Register completions from _WT_COMPLETION_DEFS
+# Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
+    # Extract command name from definition
+    # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
     cmd="${def%%=*}"
+
+    # Extract source function name from definition
+    # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
     # Create completion function dynamically
+    # Example: For cmd="wt-add", creates function "_wt_add_completion"
+    # The function calls $source_fn to get completion candidates
     eval "_${cmd//-/_}_completion() {
         local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
         COMPREPLY=(\$(compgen -W \"\$($source_fn)\" -- \"\$cur\"))
     }"
 
-    # Register the completion
+    # Register the completion function for the command
+    # Example: complete -F _wt_add_completion wt-add
     complete -F "_${cmd//-/_}_completion" "$cmd"
 done

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -14,10 +14,9 @@ for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_function_name="$(_wt_get_source_function_name "$definition")"
 
-    # Generate completion function name
-    # ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
+    # Generate completion function name using helper function
     # Example: "wt-add" -> "_wt_add_completion"
-    completion_function_name="_${command_name//-/_}_completion"
+    completion_function_name="$(_wt_get_completion_function_name "$command_name")"
 
     # Create completion function dynamically
     # The function calls $source_function_name to get completion candidates

--- a/scripts/worktree/branch-completion/for-bash.sh
+++ b/scripts/worktree/branch-completion/for-bash.sh
@@ -5,28 +5,28 @@
 
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
-for def in "${_WT_COMPLETION_DEFS[@]}"; do
+for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Extract command name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
-    cmd="$(_wt_get_command_name "$def")"
+    command_name="$(_wt_get_command_name "$definition")"
 
     # Extract source function name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
-    source_fn="$(_wt_get_source_function_name "$def")"
+    source_function_name="$(_wt_get_source_function_name "$definition")"
 
     # Generate completion function name
-    # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
+    # ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
     # Example: "wt-add" -> "_wt_add_completion"
-    completion_fn="_${cmd//-/_}_completion"
+    completion_function_name="_${command_name//-/_}_completion"
 
     # Create completion function dynamically
-    # The function calls $source_fn to get completion candidates
-    eval "$completion_fn() {
+    # The function calls $source_function_name to get completion candidates
+    eval "$completion_function_name() {
         local cur=\"\${COMP_WORDS[COMP_CWORD]}\"
-        COMPREPLY=(\$(compgen -W \"\$($source_fn)\" -- \"\$cur\"))
+        COMPREPLY=(\$(compgen -W \"\$($source_function_name)\" -- \"\$cur\"))
     }"
 
     # Register the completion function for the command
     # Example: complete -F _wt_add_completion wt-add
-    complete -F "$completion_fn" "$cmd"
+    complete -F "$completion_function_name" "$command_name"
 done

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -5,29 +5,29 @@
 
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
-for def in "${_WT_COMPLETION_DEFS[@]}"; do
+for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Extract command name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
-    cmd="$(_wt_get_command_name "$def")"
+    command_name="$(_wt_get_command_name "$definition")"
 
     # Extract source function name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
-    source_fn="$(_wt_get_source_function_name "$def")"
+    source_function_name="$(_wt_get_source_function_name "$definition")"
 
     # Generate completion function name
-    # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
+    # ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
     # Example: "wt-add" -> "_wt_add"
-    completion_fn="_${cmd//-/_}"
+    completion_function_name="_${command_name//-/_}"
 
     # Create completion function dynamically
-    # The function calls $source_fn to get completion candidates
-    eval "$completion_fn() {
+    # The function calls $source_function_name to get completion candidates
+    eval "$completion_function_name() {
         local items
-        items=(\"\${(@f)\$($source_fn)}\")
+        items=(\"\${(@f)\$($source_function_name)}\")
         _describe 'item' items
     }"
 
     # Register the completion function for the command
     # Example: compdef _wt_add wt-add
-    compdef "$completion_fn" "$cmd"
+    compdef "$completion_function_name" "$command_name"
 done

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -10,6 +10,26 @@ _wt_get_completion_function_name() {
     echo "_${command_name//-/_}"
 }
 
+# Define a completion function dynamically
+# Example: _wt_define_completion_function "_wt_add" "_wt_get_all_branches"
+_wt_define_completion_function() {
+    local completion_function_name="$1"
+    local source_function_name="$2"
+    eval "$completion_function_name() {
+        local items
+        items=(\"\${(@f)\$($source_function_name)}\")
+        _describe 'item' items
+    }"
+}
+
+# Register completion function for a command
+# Example: _wt_register_completion "_wt_add" "wt-add"
+_wt_register_completion() {
+    local completion_function_name="$1"
+    local command_name="$2"
+    compdef "$completion_function_name" "$command_name"
+}
+
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for definition in "${_WT_COMPLETION_DEFS[@]}"; do
@@ -25,15 +45,7 @@ for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add" -> "_wt_add"
     completion_function_name="$(_wt_get_completion_function_name "$command_name")"
 
-    # Create completion function dynamically
-    # The function calls $source_function_name to get completion candidates
-    eval "$completion_function_name() {
-        local items
-        items=(\"\${(@f)\$($source_function_name)}\")
-        _describe 'item' items
-    }"
-
-    # Register the completion function for the command
-    # Example: compdef _wt_add wt-add
-    compdef "$completion_function_name" "$command_name"
+    # Create and register completion function
+    _wt_define_completion_function "$completion_function_name" "$source_function_name"
+    _wt_register_completion "$completion_function_name" "$command_name"
 done

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -14,10 +14,9 @@ for definition in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_function_name="$(_wt_get_source_function_name "$definition")"
 
-    # Generate completion function name
-    # ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
+    # Generate completion function name using helper function
     # Example: "wt-add" -> "_wt_add"
-    completion_function_name="_${command_name//-/_}"
+    completion_function_name="$(_wt_get_completion_function_name "$command_name")"
 
     # Create completion function dynamically
     # The function calls $source_function_name to get completion candidates

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -4,17 +4,26 @@
 # This file is sourced by scripts/worktree/branch-completion/main.sh
 
 # Register completions from _WT_COMPLETION_DEFS
+# Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
+    # Extract command name from definition
+    # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
     cmd="${def%%=*}"
+
+    # Extract source function name from definition
+    # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
     # Create completion function dynamically
+    # Example: For cmd="wt-add", creates function "_wt_add"
+    # The function calls $source_fn to get completion candidates
     eval "_${cmd//-/_}() {
         local items
         items=(\"\${(@f)\$($source_fn)}\")
         _describe 'item' items
     }"
 
-    # Register the completion
+    # Register the completion function for the command
+    # Example: compdef _wt_add wt-add
     compdef "_${cmd//-/_}" "$cmd"
 done

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -6,15 +6,13 @@
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
-    # Extract command name from definition using parameter expansion
-    # ${var%%pattern} removes longest match of pattern from the end
+    # Extract command name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
-    cmd="${def%%=*}"
+    cmd="$(_wt_get_command_name "$def")"
 
-    # Extract source function name from definition using parameter expansion
-    # ${var#pattern} removes shortest match of pattern from the beginning
+    # Extract source function name using helper function
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
-    source_fn="${def#*=}"
+    source_fn="$(_wt_get_source_function_name "$def")"
 
     # Generate completion function name
     # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -3,6 +3,13 @@
 # Zsh completion for worktree commands
 # This file is sourced by scripts/worktree/branch-completion/main.sh
 
+# Generate completion function name for Zsh
+# Example: "wt-add" -> "_wt_add"
+_wt_get_completion_function_name() {
+    local command_name="$1"
+    echo "_${command_name//-/_}"
+}
+
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for definition in "${_WT_COMPLETION_DEFS[@]}"; do

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+
+# Zsh completion for worktree commands
+# This file is sourced by scripts/worktree/main.sh
+
+# Completion for wt-add (all branches)
+_wt_add() {
+    local branches
+    branches=("${(@f)$(_wt_get_all_branches)}")
+    _describe 'branch' branches
+}
+compdef _wt_add wt-add
+
+# Completion for wt-remove (existing worktrees)
+_wt_remove() {
+    local worktrees
+    worktrees=("${(@f)$(_wt_get_worktrees)}")
+    _describe 'worktree' worktrees
+}
+compdef _wt_remove wt-remove
+
+# Completion for wt-dev (existing worktrees)
+_wt_dev() {
+    local worktrees
+    worktrees=("${(@f)$(_wt_get_worktrees)}")
+    _describe 'worktree' worktrees
+}
+compdef _wt_dev wt-dev
+
+# Completion for wt-cd (existing worktrees)
+_wt_cd() {
+    local worktrees
+    worktrees=("${(@f)$(_wt_get_worktrees)}")
+    _describe 'worktree' worktrees
+}
+compdef _wt_cd wt-cd

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -16,11 +16,14 @@ for def in "${_WT_COMPLETION_DEFS[@]}"; do
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
-    # Create completion function dynamically
+    # Generate completion function name
     # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
-    # Example: For cmd="wt-add", creates function "_wt_add"
+    # Example: "wt-add" -> "_wt_add"
+    completion_fn="_${cmd//-/_}"
+
+    # Create completion function dynamically
     # The function calls $source_fn to get completion candidates
-    eval "_${cmd//-/_}() {
+    eval "$completion_fn() {
         local items
         items=(\"\${(@f)\$($source_fn)}\")
         _describe 'item' items
@@ -28,5 +31,5 @@ for def in "${_WT_COMPLETION_DEFS[@]}"; do
 
     # Register the completion function for the command
     # Example: compdef _wt_add wt-add
-    compdef "_${cmd//-/_}" "$cmd"
+    compdef "$completion_fn" "$cmd"
 done

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -6,15 +6,18 @@
 # Register completions from _WT_COMPLETION_DEFS
 # Example: _WT_COMPLETION_DEFS=("wt-add=_wt_get_all_branches" "wt-dev=_wt_get_worktrees")
 for def in "${_WT_COMPLETION_DEFS[@]}"; do
-    # Extract command name from definition
+    # Extract command name from definition using parameter expansion
+    # ${var%%pattern} removes longest match of pattern from the end
     # Example: "wt-add=_wt_get_all_branches" -> "wt-add"
     cmd="${def%%=*}"
 
-    # Extract source function name from definition
+    # Extract source function name from definition using parameter expansion
+    # ${var#pattern} removes shortest match of pattern from the beginning
     # Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
     source_fn="${def#*=}"
 
     # Create completion function dynamically
+    # ${cmd//-/_} replaces all "-" with "_" in cmd (e.g., "wt-add" -> "wt_add")
     # Example: For cmd="wt-add", creates function "_wt_add"
     # The function calls $source_fn to get completion candidates
     eval "_${cmd//-/_}() {

--- a/scripts/worktree/branch-completion/for-zsh.sh
+++ b/scripts/worktree/branch-completion/for-zsh.sh
@@ -1,36 +1,20 @@
 #!/bin/zsh
 
 # Zsh completion for worktree commands
-# This file is sourced by scripts/worktree/main.sh
+# This file is sourced by scripts/worktree/branch-completion/main.sh
 
-# Completion for wt-add (all branches)
-_wt_add() {
-    local branches
-    branches=("${(@f)$(_wt_get_all_branches)}")
-    _describe 'branch' branches
-}
-compdef _wt_add wt-add
+# Register completions from _WT_COMPLETION_DEFS
+for def in "${_WT_COMPLETION_DEFS[@]}"; do
+    cmd="${def%%=*}"
+    source_fn="${def#*=}"
 
-# Completion for wt-remove (existing worktrees)
-_wt_remove() {
-    local worktrees
-    worktrees=("${(@f)$(_wt_get_worktrees)}")
-    _describe 'worktree' worktrees
-}
-compdef _wt_remove wt-remove
+    # Create completion function dynamically
+    eval "_${cmd//-/_}() {
+        local items
+        items=(\"\${(@f)\$($source_fn)}\")
+        _describe 'item' items
+    }"
 
-# Completion for wt-dev (existing worktrees)
-_wt_dev() {
-    local worktrees
-    worktrees=("${(@f)$(_wt_get_worktrees)}")
-    _describe 'worktree' worktrees
-}
-compdef _wt_dev wt-dev
-
-# Completion for wt-cd (existing worktrees)
-_wt_cd() {
-    local worktrees
-    worktrees=("${(@f)$(_wt_get_worktrees)}")
-    _describe 'worktree' worktrees
-}
-compdef _wt_cd wt-cd
+    # Register the completion
+    compdef "_${cmd//-/_}" "$cmd"
+done

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -46,20 +46,6 @@ _wt_get_source_function_name() {
     echo "${def#*=}"
 }
 
-# Generate completion function name from command name
-# ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
-# Example (Bash): "wt-add" -> "_wt_add_completion"
-# Example (Zsh):  "wt-add" -> "_wt_add"
-_wt_get_completion_function_name() {
-    local command_name="$1"
-    local base_name="_${command_name//-/_}"
-    if [ -n "$BASH_VERSION" ]; then
-        echo "${base_name}_completion"
-    else
-        echo "$base_name"
-    fi
-}
-
 # Source shell-specific completion
 if [ -n "$BASH_VERSION" ]; then
     source "$COMPLETION_DIR/for-bash.sh"

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -32,6 +32,20 @@ _WT_COMPLETION_DEFS=(
     "wt-cd=_wt_get_worktrees"
 )
 
+# Extract command name from definition
+# Example: "wt-add=_wt_get_all_branches" -> "wt-add"
+_wt_get_command_name() {
+    local def="$1"
+    echo "${def%%=*}"
+}
+
+# Extract source function name from definition
+# Example: "wt-add=_wt_get_all_branches" -> "_wt_get_all_branches"
+_wt_get_source_function_name() {
+    local def="$1"
+    echo "${def#*=}"
+}
+
 # Source shell-specific completion
 if [ -n "$BASH_VERSION" ]; then
     source "$COMPLETION_DIR/for-bash.sh"

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Branch completion main entry point
+# This file is sourced by scripts/worktree/main.sh
+
+# Get the directory where this script is located
+COMPLETION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get list of all branches (local and remote)
+_wt_get_all_branches() {
+    git -C "$REPO_ROOT" branch -a 2>/dev/null | \
+        sed 's/^[* ]*//' | \
+        sed 's|^remotes/origin/||' | \
+        grep -v '^HEAD' | \
+        sort -u
+}
+
+# Get list of existing worktrees
+_wt_get_worktrees() {
+    local worktree_dir="$REPO_ROOT/worktrees"
+    if [ -d "$worktree_dir" ]; then
+        ls -1 "$worktree_dir" 2>/dev/null
+    fi
+}
+
+# Source shell-specific completion
+if [ -n "$BASH_VERSION" ]; then
+    source "$COMPLETION_DIR/for-bash.sh"
+elif [ -n "$ZSH_VERSION" ]; then
+    source "$COMPLETION_DIR/for-zsh.sh"
+fi

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -46,6 +46,20 @@ _wt_get_source_function_name() {
     echo "${def#*=}"
 }
 
+# Generate completion function name from command name
+# ${command_name//-/_} replaces all "-" with "_" (e.g., "wt-add" -> "wt_add")
+# Example (Bash): "wt-add" -> "_wt_add_completion"
+# Example (Zsh):  "wt-add" -> "_wt_add"
+_wt_get_completion_function_name() {
+    local command_name="$1"
+    local base_name="_${command_name//-/_}"
+    if [ -n "$BASH_VERSION" ]; then
+        echo "${base_name}_completion"
+    else
+        echo "$base_name"
+    fi
+}
+
 # Source shell-specific completion
 if [ -n "$BASH_VERSION" ]; then
     source "$COMPLETION_DIR/for-bash.sh"

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -23,6 +23,15 @@ _wt_get_worktrees() {
     fi
 }
 
+# Completion definitions: command=source_function
+# Add new commands here to enable completion
+_WT_COMPLETION_DEFS=(
+    "wt-add=_wt_get_all_branches"
+    "wt-remove=_wt_get_worktrees"
+    "wt-dev=_wt_get_worktrees"
+    "wt-cd=_wt_get_worktrees"
+)
+
 # Source shell-specific completion
 if [ -n "$BASH_VERSION" ]; then
     source "$COMPLETION_DIR/for-bash.sh"

--- a/scripts/worktree/main.sh
+++ b/scripts/worktree/main.sh
@@ -89,30 +89,5 @@ wt-dev() {
     make -C "$REPO_ROOT" wt-dev BRANCH="$BRANCH"
 }
 
-# ============================================================
-# Bash/Zsh completion functions
-# ============================================================
-
-# Get list of all branches (local and remote)
-_wt_get_all_branches() {
-    git -C "$REPO_ROOT" branch -a 2>/dev/null | \
-        sed 's/^[* ]*//' | \
-        sed 's|^remotes/origin/||' | \
-        grep -v '^HEAD' | \
-        sort -u
-}
-
-# Get list of existing worktrees
-_wt_get_worktrees() {
-    local worktree_dir="$REPO_ROOT/worktrees"
-    if [ -d "$worktree_dir" ]; then
-        ls -1 "$worktree_dir" 2>/dev/null
-    fi
-}
-
-# Source shell-specific completion
-if [ -n "$BASH_VERSION" ]; then
-    source "$SCRIPT_DIR/branch-completion/for-bash.sh"
-elif [ -n "$ZSH_VERSION" ]; then
-    source "$SCRIPT_DIR/branch-completion/for-zsh.sh"
-fi
+# Source branch completion functions
+source "$SCRIPT_DIR/branch-completion/main.sh"

--- a/scripts/worktree/main.sh
+++ b/scripts/worktree/main.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Worktree navigation helper functions
-# Add this to your shell profile: source /path/to/scripts/wt-cd.sh
+# This file is sourced by scripts/main.sh
 
 # Get the directory where this script is located
 # Note: These variables are evaluated once when sourcing this file
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
 
 # Source the check logic functions
-source "$SCRIPT_DIR/worktree/check_logic.sh"
+source "$SCRIPT_DIR/check_logic.sh"
 
 # Navigate to a specific worktree by branch name
 # Usage: wt-cd branch-name

--- a/scripts/worktree/main.sh
+++ b/scripts/worktree/main.sh
@@ -110,68 +110,9 @@ _wt_get_worktrees() {
     fi
 }
 
-# Bash completion
+# Source shell-specific completion
 if [ -n "$BASH_VERSION" ]; then
-    # Completion for wt-add (all branches)
-    _wt_add_completion() {
-        local cur="${COMP_WORDS[COMP_CWORD]}"
-        COMPREPLY=($(compgen -W "$(_wt_get_all_branches)" -- "$cur"))
-    }
-    complete -F _wt_add_completion wt-add
-
-    # Completion for wt-remove (existing worktrees)
-    _wt_remove_completion() {
-        local cur="${COMP_WORDS[COMP_CWORD]}"
-        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-    }
-    complete -F _wt_remove_completion wt-remove
-
-    # Completion for wt-dev (existing worktrees)
-    _wt_dev_completion() {
-        local cur="${COMP_WORDS[COMP_CWORD]}"
-        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-    }
-    complete -F _wt_dev_completion wt-dev
-
-    # Completion for wt-cd (existing worktrees)
-    _wt_cd_completion() {
-        local cur="${COMP_WORDS[COMP_CWORD]}"
-        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
-    }
-    complete -F _wt_cd_completion wt-cd
-fi
-
-# Zsh completion
-if [ -n "$ZSH_VERSION" ]; then
-    # Completion for wt-add (all branches)
-    _wt_add() {
-        local branches
-        branches=("${(@f)$(_wt_get_all_branches)}")
-        _describe 'branch' branches
-    }
-    compdef _wt_add wt-add
-
-    # Completion for wt-remove (existing worktrees)
-    _wt_remove() {
-        local worktrees
-        worktrees=("${(@f)$(_wt_get_worktrees)}")
-        _describe 'worktree' worktrees
-    }
-    compdef _wt_remove wt-remove
-
-    # Completion for wt-dev (existing worktrees)
-    _wt_dev() {
-        local worktrees
-        worktrees=("${(@f)$(_wt_get_worktrees)}")
-        _describe 'worktree' worktrees
-    }
-    compdef _wt_dev wt-dev
-
-    # Completion for wt-cd (existing worktrees)
-    _wt_cd() {
-        local worktrees
-        worktrees=("${(@f)$(_wt_get_worktrees)}")
-        _describe 'worktree' worktrees
-    }
-    compdef _wt_cd wt-cd
+    source "$SCRIPT_DIR/branch-completion/for-bash.sh"
+elif [ -n "$ZSH_VERSION" ]; then
+    source "$SCRIPT_DIR/branch-completion/for-zsh.sh"
 fi

--- a/scripts/wt-cd.sh
+++ b/scripts/wt-cd.sh
@@ -52,3 +52,126 @@ wt-cd-current() {
     # Delegate to wt-cd
     wt-cd "$BRANCH"
 }
+
+# Shell wrapper functions for worktree commands with Tab completion
+# These provide shorter alternatives to make commands
+
+# wt-add: Create worktree for branch
+# Usage: wt-add <branch-name>
+wt-add() {
+    local BRANCH="$1"
+    if [ -z "$BRANCH" ]; then
+        echo "Usage: wt-add <branch-name>"
+        return 1
+    fi
+    make -C "$REPO_ROOT" wt-add BRANCH="$BRANCH"
+}
+
+# wt-remove: Remove worktree
+# Usage: wt-remove <branch-name>
+wt-remove() {
+    local BRANCH="$1"
+    if [ -z "$BRANCH" ]; then
+        echo "Usage: wt-remove <branch-name>"
+        return 1
+    fi
+    make -C "$REPO_ROOT" wt-remove BRANCH="$BRANCH"
+}
+
+# wt-dev: Start development server for worktree
+# Usage: wt-dev <branch-name>
+wt-dev() {
+    local BRANCH="$1"
+    if [ -z "$BRANCH" ]; then
+        echo "Usage: wt-dev <branch-name>"
+        return 1
+    fi
+    make -C "$REPO_ROOT" wt-dev BRANCH="$BRANCH"
+}
+
+# ============================================================
+# Bash/Zsh completion functions
+# ============================================================
+
+# Get list of all branches (local and remote)
+_wt_get_all_branches() {
+    git -C "$REPO_ROOT" branch -a 2>/dev/null | \
+        sed 's/^[* ]*//' | \
+        sed 's|^remotes/origin/||' | \
+        grep -v '^HEAD' | \
+        sort -u
+}
+
+# Get list of existing worktrees
+_wt_get_worktrees() {
+    local worktree_dir="$REPO_ROOT/worktrees"
+    if [ -d "$worktree_dir" ]; then
+        ls -1 "$worktree_dir" 2>/dev/null
+    fi
+}
+
+# Bash completion
+if [ -n "$BASH_VERSION" ]; then
+    # Completion for wt-add (all branches)
+    _wt_add_completion() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=($(compgen -W "$(_wt_get_all_branches)" -- "$cur"))
+    }
+    complete -F _wt_add_completion wt-add
+
+    # Completion for wt-remove (existing worktrees)
+    _wt_remove_completion() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+    }
+    complete -F _wt_remove_completion wt-remove
+
+    # Completion for wt-dev (existing worktrees)
+    _wt_dev_completion() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+    }
+    complete -F _wt_dev_completion wt-dev
+
+    # Completion for wt-cd (existing worktrees)
+    _wt_cd_completion() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=($(compgen -W "$(_wt_get_worktrees)" -- "$cur"))
+    }
+    complete -F _wt_cd_completion wt-cd
+fi
+
+# Zsh completion
+if [ -n "$ZSH_VERSION" ]; then
+    # Completion for wt-add (all branches)
+    _wt_add() {
+        local branches
+        branches=("${(@f)$(_wt_get_all_branches)}")
+        _describe 'branch' branches
+    }
+    compdef _wt_add wt-add
+
+    # Completion for wt-remove (existing worktrees)
+    _wt_remove() {
+        local worktrees
+        worktrees=("${(@f)$(_wt_get_worktrees)}")
+        _describe 'worktree' worktrees
+    }
+    compdef _wt_remove wt-remove
+
+    # Completion for wt-dev (existing worktrees)
+    _wt_dev() {
+        local worktrees
+        worktrees=("${(@f)$(_wt_get_worktrees)}")
+        _describe 'worktree' worktrees
+    }
+    compdef _wt_dev wt-dev
+
+    # Completion for wt-cd (existing worktrees)
+    _wt_cd() {
+        local worktrees
+        worktrees=("${(@f)$(_wt_get_worktrees)}")
+        _describe 'worktree' worktrees
+    }
+    compdef _wt_cd wt-cd
+fi


### PR DESCRIPTION
…mmands

Add wt-add, wt-remove, wt-dev shell wrapper functions that provide shorter alternatives to make commands with Tab completion support for both Bash and Zsh:
- wt-add: completes all local/remote branches
- wt-remove/wt-dev/wt-cd: completes existing worktrees

Re-implementation of PR #230 from develop branch.