### PR TITLE
Fix Storybook to work with Git worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ make wt-current                 # Show currently active worktree
 **Development Commands:**
 ```bash
 make wt-dev BRANCH=feature-x    # Start dev server for worktree (RECOMMENDED)
+make wt-storybook               # Start Storybook in worktree mode
 make wt-down                    # Stop worktree Docker containers
 make wt-up                      # Start worktree Docker containers
 make wt-disable                 # Disable worktree mode, return to main repository

--- a/docs/GIT_WORKTREE.md
+++ b/docs/GIT_WORKTREE.md
@@ -98,6 +98,9 @@ make wt-down
 
 # worktreeのDockerコンテナを起動
 make wt-up
+
+# worktreeモードでStorybookを起動
+make wt-storybook
 ```
 
 注：これらのコマンドは`.env.worktree`の設定を使用します。
@@ -224,6 +227,7 @@ make wt-remove BRANCH=your-branch
 | `wt-prune` | 不要なworktree参照を削除 | `make wt-prune` |
 | `wt-current` | 現在アクティブなworktreeを表示 | `make wt-current` |
 | `wt-dev` | worktreeで開発サーバーを起動 | `make wt-dev BRANCH=feature-x` |
+| `wt-storybook` | worktreeモードでStorybookを起動 | `make wt-storybook` |
 | `wt-disable` | worktreeモードを無効化、メインリポジトリに戻る | `make wt-disable` |
 | `wt-down` | worktreeのDockerコンテナを停止 | `make wt-down` |
 | `wt-up` | worktreeのDockerコンテナを起動 | `make wt-up` |

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -1,5 +1,5 @@
 # Git Worktree Commands
-.PHONY: wt-list wt-add wt-remove wt-prune wt-current wt-dev wt-down wt-up wt-disable
+.PHONY: wt-list wt-add wt-remove wt-prune wt-current wt-dev wt-down wt-up wt-disable wt-storybook
 
 # Common variables
 WORKTREE_DIR := worktrees
@@ -80,3 +80,7 @@ wt-disable:
 	@rm -f docker-compose.override.yml .env.worktree
 	@$(MAKE) dev
 	@echo "Switched back to main repository mode"
+
+wt-storybook:
+	@echo "Starting Storybook in worktree mode..."
+	@$(_wt-load-env-exec) docker compose exec frontend npm run storybook


### PR DESCRIPTION
Add make wt-storybook command that loads .env.worktree environment variables so Storybook can read source code from the worktree directory instead of the main repository.