### PR TITLE
Debug wt-add branch name error

### DIFF
--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -64,6 +64,8 @@ _wt-init: _wt-check-branch _wt-check-exists
 	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
 	@echo "Switching to worktree for initialization..."
 	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
+	@echo "Stopping existing Docker services..."
+	@$(MAKE) wt-down
 	@echo "Starting Docker services for worktree..."
 	@$(MAKE) wt-up
 	@echo "Installing npm dependencies in worktree..."


### PR DESCRIPTION
When initializing a worktree with wt-add, the existing container from the main repository could remain running with the wrong volume mount. This caused the container's working directory to not exist because the worktree path was not mounted.

Add wt-down before wt-up in _wt-init to ensure containers are recreated with the correct worktree volume mount configuration.