### PR TITLE
Refactor worktree initialization into standalone function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,8 @@ For working on multiple branches simultaneously:
 **Basic Commands:**
 ```bash
 make wt-list                    # List all worktrees
-make wt-add BRANCH=feature-x    # Create worktree for branch (includes auto-initialization)
+make wt-add BRANCH=feature-x    # Create worktree for branch (file copy only, no Docker)
+make wt-init BRANCH=feature-x   # Initialize worktree for development (Docker, npm install)
 make wt-remove BRANCH=feature-x # Remove worktree
 make wt-prune                   # Clean up stale references
 make wt-current                 # Show currently active worktree
@@ -117,7 +118,7 @@ make wt-current                 # Show currently active worktree
 
 **Development Commands:**
 ```bash
-make wt-dev BRANCH=feature-x    # Start dev server for worktree (auto-creates if missing)
+make wt-dev BRANCH=feature-x    # Start dev server for worktree (auto-initializes if needed)
 make storybook                  # Start Storybook (works in both main repo and worktree mode)
 make wt-down                    # Stop worktree Docker containers
 make wt-up                      # Start worktree Docker containers
@@ -161,8 +162,9 @@ make wt-remove BRANCH=new-feature
 ```
 
 **Key Features:**
-- `make wt-dev` automatically creates the worktree if it doesn't exist (calls `wt-add` internally) and stops other worktree containers to avoid port conflicts
-- `make wt-add` automatically initializes the worktree (copies .env, matchUrl.ts, runs npm install, etc.)
+- `make wt-dev` automatically initializes the worktree if not initialized (calls `wt-init` internally, which calls `wt-add` if needed) and stops other worktree containers to avoid port conflicts
+- `make wt-add` creates the worktree and copies configuration files (.env, matchUrl.ts) but does not run Docker or npm install
+- `make wt-init` initializes the development environment (Docker setup, npm install, wxt prepare)
 - Each worktree has its own node_modules and package.json (no cross-branch contamination)
 - Internal helper commands (starting with `_`) should not be used directly
 

--- a/docs/GIT_WORKTREE.md
+++ b/docs/GIT_WORKTREE.md
@@ -26,6 +26,7 @@ source /path/to/frog-frame-front/scripts/main.sh
 | コマンド | 説明 | Tab補完対象 |
 |---------|------|-------------|
 | `wt-add <branch>` | worktree作成 | 全ブランチ（ローカル/リモート） |
+| `wt-init <branch>` | worktree初期化 | 全ブランチ（ローカル/リモート） |
 | `wt-remove <branch>` | worktree削除 | 既存worktree |
 | `wt-dev <branch>` | 開発サーバー起動 | 既存worktree |
 
@@ -34,6 +35,9 @@ source /path/to/frog-frame-front/scripts/main.sh
 ```bash
 # Tab補完でブランチを選択してworktree作成
 wt-add feat<TAB>  # → wt-add feature-branch
+
+# Tab補完でブランチを選択してworktree初期化
+wt-init feat<TAB>  # → wt-init feature-branch
 
 # Tab補完で既存worktreeを選択して開発開始
 wt-dev feat<TAB>  # → wt-dev feature-branch
@@ -47,6 +51,7 @@ wt-remove feat<TAB>  # → wt-remove feature-branch
 | シェルラッパー | 対応するmakeコマンド |
 |---------------|---------------------|
 | `wt-add feature-x` | `make wt-add BRANCH=feature-x` |
+| `wt-init feature-x` | `make wt-init BRANCH=feature-x` |
 | `wt-remove feature-x` | `make wt-remove BRANCH=feature-x` |
 | `wt-dev feature-x` | `make wt-dev BRANCH=feature-x` |
 
@@ -288,6 +293,7 @@ make wt-remove BRANCH=your-branch
 | コマンド | 説明 | Tab補完対象 |
 |---------|------|-------------|
 | `wt-add <branch>` | worktree作成 | 全ブランチ（ローカル/リモート） |
+| `wt-init <branch>` | worktree初期化（Docker、npm install） | 全ブランチ（ローカル/リモート） |
 | `wt-remove <branch>` | worktree削除 | 既存worktree |
 | `wt-dev <branch>` | 開発サーバー起動 | 既存worktree |
 | `wt-cd <branch>` | worktreeディレクトリへ移動 | 既存worktree |

--- a/docs/GIT_WORKTREE.md
+++ b/docs/GIT_WORKTREE.md
@@ -83,20 +83,32 @@ make wt-list
 #### 新規worktree作成
 
 ```bash
-# 既存ブランチをworktreeとして追加（自動で初期化も実行）
+# 既存ブランチをworktreeとして追加
 make wt-add BRANCH=feature-branch
 
-# 新しいブランチを作成してworktreeとして追加（自動で初期化も実行）
+# 新しいブランチを作成してworktreeとして追加
 make wt-add BRANCH=new-feature-branch
 ```
 
-`wt-add`コマンドは以下の処理を自動実行します：
+`wt-add`コマンドは以下の処理を実行します：
 - worktreeディレクトリの作成
 - ブランチの作成/チェックアウト
-- **自動初期化**: 設定ファイル（.env、matchUrl.ts）の自動コピー
-- **自動初期化**: Docker環境の切り替え
-- **自動初期化**: npm install の実行
-- **自動初期化**: WXT準備（npx wxt prepare）の実行
+- 設定ファイル（.env、matchUrl.ts）のコピー
+
+**注**: Docker環境のセットアップやnpm installは行いません。開発を開始するには`wt-init`または`wt-dev`を実行してください。
+
+#### worktree初期化
+
+```bash
+# worktreeの開発環境を初期化（Docker、npm install、wxt prepare）
+make wt-init BRANCH=feature-branch
+```
+
+`wt-init`コマンドは以下の処理を実行します：
+- worktreeが存在しない場合は自動的に`wt-add`を実行
+- Docker環境の切り替え（docker-compose.override.yml、.env.worktreeの作成）
+- npm install の実行
+- WXT準備（npx wxt prepare）の実行
 
 #### worktree削除
 
@@ -123,7 +135,7 @@ make wt-dev BRANCH=other-branch
 ```
 
 `wt-dev`コマンドは以下を自動実行します：
-- **worktreeが存在しない場合は自動的に`wt-add`を実行**
+- **worktreeが初期化されていない場合は自動的に`wt-init`を実行**（worktreeが存在しない場合は`wt-add`も実行）
 - 他のworktreeのDockerコンテナを自動停止
 - ポート3000の競合回避
 - 指定されたworktreeディレクトリで独立した開発環境を起動
@@ -177,10 +189,7 @@ wt-cd-current         # 現在のworktreeへ移動
 
 ```bash
 # メインでfeature-Aを開発中
-# 緊急バグ修正のためhotfixブランチを作成（自動で初期化も実行）
-make wt-add BRANCH=hotfix-critical-bug
-
-# hotfixブランチに切り替えて開発開始
+# 緊急バグ修正のためhotfixブランチで開発開始（自動でwt-add、wt-initも実行）
 make wt-dev BRANCH=hotfix-critical-bug
 # ... バグ修正作業 ...
 
@@ -194,32 +203,22 @@ make wt-remove BRANCH=hotfix-critical-bug
 ### 例2: 複数機能の切り替え開発
 
 ```bash
-# feature-Aのworktreeを作成（自動で初期化も実行）
-make wt-add BRANCH=feature-A
-
-# feature-Bのworktreeを作成（自動で初期化も実行）
-make wt-add BRANCH=feature-B
-
-# feature-Aで開発開始
+# feature-Aで開発開始（自動でwt-add、wt-initも実行）
 make wt-dev BRANCH=feature-A
 # ... 機能A開発 ...
 
-# feature-Bに切り替え（自動的にfeature-Aの環境を停止）
+# feature-Bに切り替え（自動的にfeature-Aの環境を停止、feature-Bをwt-add、wt-init）
 make wt-dev BRANCH=feature-B
 # ... 機能B開発 ...
 
-# 再度feature-Aに戻る
+# 再度feature-Aに戻る（すでに初期化済みなのでそのまま起動）
 make wt-dev BRANCH=feature-A
 ```
 
 ### 例3: レビュー中の並行開発
 
 ```bash
-# 現在PR中のfeature-reviewと新機能feature-nextを並行作業
-make wt-add BRANCH=feature-review
-make wt-add BRANCH=feature-next
-
-# レビュー対応作業
+# 現在PR中のfeature-reviewでレビュー対応作業開始
 make wt-dev BRANCH=feature-review
 # ... レビュー修正 ...
 
@@ -233,12 +232,12 @@ make wt-dev BRANCH=feature-review
 
 ## 注意事項
 
-1. **自動初期化**: `wt-add`実行時に自動的に初期化されるため、手動での初期化は不要です
-2. **推奨コマンド**: 切り替えには`make wt-dev`を使用してください（自動でポート競合を回避）
+1. **推奨コマンド**: 開発には`make wt-dev`を使用してください（自動でwt-add、wt-initを実行し、ポート競合も回避）
+2. **段階的なセットアップ**: 必要に応じて`wt-add`（worktree作成のみ）と`wt-init`（Docker環境セットアップ）を個別に実行できます
 3. **ディスク容量**: 各worktreeはnode_modulesを持つため、ディスク容量に注意してください
 4. **worktreeディレクトリ**: `worktrees/`ディレクトリは`.gitignore`で除外されています
 5. **自動化された切り替え**: `wt-dev`コマンドにより他のコンテナ停止・環境切り替え・開発サーバー起動が自動化されています
-6. **内部ヘルパー関数**: `_`で始まるコマンド（例：`_wt-init`）は内部使用のみで、直接実行する必要はありません
+6. **内部ヘルパー関数**: `_`で始まるコマンド（例：`_wt-setup-env`）は内部使用のみで、直接実行しないでください
 
 ## 簡単ワークフロー（まとめ）
 
@@ -272,11 +271,12 @@ make wt-remove BRANCH=your-branch
 | コマンド | 説明 | 使用例 |
 |---------|------|--------|
 | `wt-list` | すべてのworktreeを一覧表示 | `make wt-list` |
-| `wt-add` | 新しいworktreeを作成（自動初期化） | `make wt-add BRANCH=feature-x` |
+| `wt-add` | 新しいworktreeを作成（ファイルコピーのみ） | `make wt-add BRANCH=feature-x` |
+| `wt-init` | worktreeの開発環境を初期化（Docker、npm install） | `make wt-init BRANCH=feature-x` |
 | `wt-remove` | worktreeを削除 | `make wt-remove BRANCH=feature-x` |
 | `wt-prune` | 不要なworktree参照を削除 | `make wt-prune` |
 | `wt-current` | 現在アクティブなworktreeを表示 | `make wt-current` |
-| `wt-dev` | worktreeで開発サーバーを起動（存在しない場合は自動作成） | `make wt-dev BRANCH=feature-x` |
+| `wt-dev` | worktreeで開発サーバーを起動（未初期化の場合は自動初期化） | `make wt-dev BRANCH=feature-x` |
 | `wt-disable` | worktreeモードを無効化、メインリポジトリに戻る | `make wt-disable` |
 | `wt-down` | worktreeのDockerコンテナを停止 | `make wt-down` |
 | `wt-up` | worktreeのDockerコンテナを起動 | `make wt-up` |

--- a/make/worktree/helpers/check_logic.mk
+++ b/make/worktree/helpers/check_logic.mk
@@ -2,20 +2,26 @@
 # Validation and check helpers for worktree operations
 .PHONY: _wt-check-branch _wt-check-exists _wt-check-no-active _wt-check-custom-override _wt-check-incomplete-setup _wt-check-initialized
 
-# Check if BRANCH variable is defined
+# Check if BRANCH variable is defined and safe
 _wt-check-branch:
 ifndef BRANCH
 	@echo "Error: BRANCH is required"
 	@echo "Usage: make $(MAKECMDGOALS) BRANCH=branch-name"
 	@exit 1
 endif
+	@# Validate branch name contains only safe characters (security measure)
+	@if ! echo "$(BRANCH)" | grep -qE '^[A-Za-z0-9._/-]+$$'; then \
+		echo "Error: Invalid branch name '$(BRANCH)'"; \
+		echo "Branch names may only contain: A-Z, a-z, 0-9, '.', '_', '/', '-'"; \
+		exit 1; \
+	fi
 
 # Check if worktree directory exists
 _wt-check-exists:
 	@if [ ! -d "$(WORKTREE_PATH)" ]; then \
 		echo "Error: Worktree not found at $(WORKTREE_PATH)"; \
 		echo "Available worktrees:"; \
-		ls -1 $(WORKTREE_DIR) 2>/dev/null || echo "No worktrees found"; \
+		ls -1 "$(WORKTREE_DIR)" 2>/dev/null || echo "No worktrees found"; \
 		exit 1; \
 	fi
 

--- a/make/worktree/helpers/check_logic.mk
+++ b/make/worktree/helpers/check_logic.mk
@@ -42,9 +42,11 @@ _wt-check-incomplete-setup:
 
 # Check if worktree is initialized for the specified branch
 # Succeeds (exit 0) if initialized, fails (exit 1) if not initialized
+# Uses check_env_worktree_exists and get_and_check_active_branch from scripts/worktree/check_logic.sh
 _wt-check-initialized:
-	@if [ -f .env.worktree ]; then \
-		ACTIVE_BRANCH=$$(grep WORKTREE_ACTIVE_BRANCH .env.worktree 2>/dev/null | cut -d'=' -f2); \
+	@source scripts/worktree/check_logic.sh && \
+	if check_env_worktree_exists >/dev/null 2>&1; then \
+		ACTIVE_BRANCH=$$(get_and_check_active_branch 2>/dev/null); \
 		if [ "$$ACTIVE_BRANCH" = "$(BRANCH)" ]; then \
 			exit 0; \
 		fi; \

--- a/make/worktree/helpers/check_logic.mk
+++ b/make/worktree/helpers/check_logic.mk
@@ -45,10 +45,6 @@ _wt-check-incomplete-setup:
 # Uses check_env_worktree_exists and get_and_check_active_branch from scripts/worktree/check_logic.sh
 _wt-check-initialized:
 	@source scripts/worktree/check_logic.sh && \
-	if check_env_worktree_exists >/dev/null 2>&1; then \
-		ACTIVE_BRANCH=$$(get_and_check_active_branch 2>/dev/null); \
-		if [ "$$ACTIVE_BRANCH" = "$(BRANCH)" ]; then \
-			exit 0; \
-		fi; \
-	fi; \
-	exit 1
+	check_env_worktree_exists >/dev/null 2>&1 || exit 1; \
+	ACTIVE_BRANCH=$$(get_and_check_active_branch 2>/dev/null) || exit 1; \
+	[ "$$ACTIVE_BRANCH" = "$(BRANCH)" ] || exit 1

--- a/make/worktree/helpers/check_logic.mk
+++ b/make/worktree/helpers/check_logic.mk
@@ -1,6 +1,6 @@
 # Git Worktree Check Logic
 # Validation and check helpers for worktree operations
-.PHONY: _wt-check-branch _wt-check-exists _wt-check-no-active _wt-check-custom-override _wt-check-incomplete-setup
+.PHONY: _wt-check-branch _wt-check-exists _wt-check-no-active _wt-check-custom-override _wt-check-incomplete-setup _wt-check-initialized
 
 # Check if BRANCH variable is defined
 _wt-check-branch:
@@ -39,3 +39,14 @@ _wt-check-incomplete-setup:
 		echo "Worktree environment configured but docker-compose.override.yml missing"; \
 		exit 0; \
 	fi
+
+# Check if worktree is initialized for the specified branch
+# Succeeds (exit 0) if initialized, fails (exit 1) if not initialized
+_wt-check-initialized:
+	@if [ -f .env.worktree ]; then \
+		ACTIVE_BRANCH=$$(grep WORKTREE_ACTIVE_BRANCH .env.worktree 2>/dev/null | cut -d'=' -f2); \
+		if [ "$$ACTIVE_BRANCH" = "$(BRANCH)" ]; then \
+			exit 0; \
+		fi; \
+	fi; \
+	exit 1

--- a/make/worktree/helpers/check_logic.mk
+++ b/make/worktree/helpers/check_logic.mk
@@ -2,26 +2,20 @@
 # Validation and check helpers for worktree operations
 .PHONY: _wt-check-branch _wt-check-exists _wt-check-no-active _wt-check-custom-override _wt-check-incomplete-setup _wt-check-initialized
 
-# Check if BRANCH variable is defined and safe
+# Check if BRANCH variable is defined
 _wt-check-branch:
 ifndef BRANCH
 	@echo "Error: BRANCH is required"
 	@echo "Usage: make $(MAKECMDGOALS) BRANCH=branch-name"
 	@exit 1
 endif
-	@# Validate branch name contains only safe characters (security measure)
-	@if ! echo "$(BRANCH)" | grep -qE '^[A-Za-z0-9._/-]+$$'; then \
-		echo "Error: Invalid branch name '$(BRANCH)'"; \
-		echo "Branch names may only contain: A-Z, a-z, 0-9, '.', '_', '/', '-'"; \
-		exit 1; \
-	fi
 
 # Check if worktree directory exists
 _wt-check-exists:
 	@if [ ! -d "$(WORKTREE_PATH)" ]; then \
 		echo "Error: Worktree not found at $(WORKTREE_PATH)"; \
 		echo "Available worktrees:"; \
-		ls -1 "$(WORKTREE_DIR)" 2>/dev/null || echo "No worktrees found"; \
+		ls -1 $(WORKTREE_DIR) 2>/dev/null || echo "No worktrees found"; \
 		exit 1; \
 	fi
 

--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -17,24 +17,24 @@ _wt-remove-orphaned:
 _wt-setup-env:
 	@echo "Setting up configuration files..."
 	@if [ -f .env ]; then \
-		cp .env $(WORKTREE_PATH)/.env; \
+		cp .env "$(WORKTREE_PATH)/.env"; \
 		echo "Copied .env to worktree"; \
 	else \
 		echo "Warning: .env not found in main repository"; \
 		if [ -f .env.example ]; then \
-			cp .env.example $(WORKTREE_PATH)/.env; \
+			cp .env.example "$(WORKTREE_PATH)/.env"; \
 			echo "Copied .env.example to worktree as .env"; \
 		fi \
 	fi
 	@if [ -f host-frontend-root/frontend-src-root/src/utils/matchUrl.ts ]; then \
-		mkdir -p $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/; \
-		cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts; \
+		mkdir -p "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/"; \
+		cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts"; \
 		echo "Copied matchUrl.ts to worktree"; \
 	else \
 		echo "Warning: matchUrl.ts not found, checking for example file"; \
 		if [ -f host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example ]; then \
-			mkdir -p $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/; \
-			cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts; \
+			mkdir -p "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/"; \
+			cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts"; \
 			echo "Copied matchUrl.ts.example to worktree as matchUrl.ts"; \
 		fi \
 	fi

--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -1,6 +1,6 @@
 # Git Worktree Initialization Helpers
 # Helpers used only during worktree add/initialization
-.PHONY: _wt-remove-orphaned _wt-setup-env _wt-copy-override-template _wt-create-override _wt-init
+.PHONY: _wt-remove-orphaned _wt-setup-env _wt-copy-override-template _wt-create-override
 
 # Remove orphaned worktree directory
 _wt-remove-orphaned:
@@ -57,24 +57,3 @@ _wt-create-override:
 	@echo "WORKTREE_ACTIVE_BRANCH=$(BRANCH)" >> .env.worktree
 	@echo "# Override HOST_FRONTEND_ROOT_PATH to mount worktree source directory" >> .env.worktree
 	@echo "HOST_FRONTEND_ROOT_PATH=./$(WORKTREE_PATH)/host-frontend-root" >> .env.worktree
-
-# Initialize worktree for development
-_wt-init: _wt-check-branch _wt-check-exists
-	@echo "Initializing worktree for development: $(BRANCH)..."
-	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
-	@echo "Switching to worktree for initialization..."
-	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
-	@echo "Stopping existing Docker services..."
-	@$(MAKE) wt-down
-	@echo "Starting Docker services for worktree..."
-	@$(MAKE) wt-up
-	@echo "Installing npm dependencies in worktree..."
-	@$(_load-env-exec) docker compose exec frontend npm install
-	@echo "Preparing WXT (generating .wxt/tsconfig.json) in worktree..."
-	@$(_load-env-exec) docker compose exec frontend npx wxt prepare
-	@echo ""
-	@echo "Worktree $(BRANCH) initialization complete!"
-	@echo "The worktree is ready for development."
-	@echo ""
-	@echo "To start development:"
-	@echo "  make wt-dev BRANCH=$(BRANCH)"

--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -17,24 +17,24 @@ _wt-remove-orphaned:
 _wt-setup-env:
 	@echo "Setting up configuration files..."
 	@if [ -f .env ]; then \
-		cp .env "$(WORKTREE_PATH)/.env"; \
+		cp .env $(WORKTREE_PATH)/.env; \
 		echo "Copied .env to worktree"; \
 	else \
 		echo "Warning: .env not found in main repository"; \
 		if [ -f .env.example ]; then \
-			cp .env.example "$(WORKTREE_PATH)/.env"; \
+			cp .env.example $(WORKTREE_PATH)/.env; \
 			echo "Copied .env.example to worktree as .env"; \
 		fi \
 	fi
 	@if [ -f host-frontend-root/frontend-src-root/src/utils/matchUrl.ts ]; then \
-		mkdir -p "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/"; \
-		cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts"; \
+		mkdir -p $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/; \
+		cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts; \
 		echo "Copied matchUrl.ts to worktree"; \
 	else \
 		echo "Warning: matchUrl.ts not found, checking for example file"; \
 		if [ -f host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example ]; then \
-			mkdir -p "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/"; \
-			cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example "$(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts"; \
+			mkdir -p $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/; \
+			cp host-frontend-root/frontend-src-root/src/utils/matchUrl.ts.example $(WORKTREE_PATH)/host-frontend-root/frontend-src-root/src/utils/matchUrl.ts; \
 			echo "Copied matchUrl.ts.example to worktree as matchUrl.ts"; \
 		fi \
 	fi

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -9,52 +9,14 @@ WORKTREE_PATH = $(WORKTREE_DIR)/$(BRANCH)
 # Include internal helpers
 include make/worktree/helpers/main.mk
 
+# Include wt-add command
+include make/worktree/wt-add.mk
+
 # Public commands
 
 wt-list:
 	@echo "Listing all git worktrees..."
 	@git worktree list
-
-wt-add: _wt-check-branch
-	@echo "Creating worktree for branch: $(BRANCH)..."
-	@mkdir -p $(dir $(WORKTREE_PATH))
-	@# Check write permissions on parent directory
-	@if ! touch "$(dir $(WORKTREE_PATH)).write_test" 2>/dev/null; then \
-		echo "Error: Cannot write to $(dir $(WORKTREE_PATH))"; \
-		echo "The directory may have been created by Docker with root permissions."; \
-		echo "Please fix permissions with: sudo chown -R $$(whoami) $(WORKTREE_DIR)/"; \
-		exit 1; \
-	fi
-	@rm -f "$(dir $(WORKTREE_PATH)).write_test"
-	@# Check if worktree already exists in git
-	@if git worktree list | awk '{print $$1}' | grep -q "^$(PWD)/$(WORKTREE_PATH)\$$"; then \
-		echo "Error: Worktree already exists at $(WORKTREE_PATH)"; \
-		echo "To remove it, run: make wt-remove BRANCH=$(BRANCH)"; \
-		exit 1; \
-	fi
-	@# Remove any orphaned directory
-	@$(MAKE) _wt-remove-orphaned BRANCH=$(BRANCH) 2>/dev/null || true
-	@# Check if branch exists locally
-	@if git show-ref --verify --quiet refs/heads/$(BRANCH); then \
-		echo "Using existing local branch: $(BRANCH)"; \
-		git worktree add $(WORKTREE_PATH) $(BRANCH); \
-	elif git ls-remote --exit-code --heads origin $(BRANCH) >/dev/null 2>&1; then \
-		echo "Creating local branch from remote: origin/$(BRANCH)"; \
-		git worktree add --track -b $(BRANCH) $(WORKTREE_PATH) origin/$(BRANCH); \
-	else \
-		echo "Creating new branch: $(BRANCH)"; \
-		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
-	fi
-	@echo "Worktree created at: $(WORKTREE_PATH)"
-	@echo "Setting up environment files..."
-	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
-	@echo ""
-	@echo "Worktree $(BRANCH) is ready."
-	@echo "To initialize for development (Docker, npm install, wxt prepare):"
-	@echo "  make wt-init BRANCH=$(BRANCH)"
-	@echo ""
-	@echo "Or start development directly (auto-initializes if needed):"
-	@echo "  make wt-dev BRANCH=$(BRANCH)"
 
 wt-remove: _wt-check-branch
 	@echo "Removing worktree for branch: $(BRANCH)..."

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -1,6 +1,6 @@
 # Git Worktree Commands
 # Note: When adding/removing/modifying commands, also update docs/GIT_WORKTREE.md
-.PHONY: wt-list wt-add wt-remove wt-prune wt-current wt-dev wt-down wt-up wt-disable
+.PHONY: wt-list wt-add wt-remove wt-prune wt-current wt-init wt-dev wt-down wt-up wt-disable
 
 # Common variables
 WORKTREE_DIR := worktrees
@@ -46,8 +46,15 @@ wt-add: _wt-check-branch
 		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
 	fi
 	@echo "Worktree created at: $(WORKTREE_PATH)"
-	@echo "Initializing worktree..."
-	@$(MAKE) _wt-init BRANCH=$(BRANCH)
+	@echo "Setting up environment files..."
+	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
+	@echo ""
+	@echo "Worktree $(BRANCH) is ready."
+	@echo "To initialize for development (Docker, npm install, wxt prepare):"
+	@echo "  make wt-init BRANCH=$(BRANCH)"
+	@echo ""
+	@echo "Or start development directly (auto-initializes if needed):"
+	@echo "  make wt-dev BRANCH=$(BRANCH)"
 
 wt-remove: _wt-check-branch
 	@echo "Removing worktree for branch: $(BRANCH)..."
@@ -72,6 +79,27 @@ wt-current:
 	@echo "Branch: $$(grep WORKTREE_ACTIVE_BRANCH .env.worktree 2>/dev/null | cut -d'=' -f2 || echo 'unknown')"
 	@echo "Path: $$(grep CURRENT_WORKTREE_PATH .env.worktree 2>/dev/null | cut -d'=' -f2 || echo 'unknown')"
 
+wt-init: _wt-check-branch
+	@# Check if worktree exists, if not create it
+	@$(MAKE) _wt-check-exists BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-add BRANCH="$(BRANCH)"
+	@echo "Initializing worktree for development: $(BRANCH)..."
+	@echo "Switching to worktree for initialization..."
+	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
+	@echo "Stopping existing Docker services..."
+	@$(MAKE) wt-down
+	@echo "Starting Docker services for worktree..."
+	@$(MAKE) wt-up
+	@echo "Installing npm dependencies in worktree..."
+	@$(_load-env-exec) docker compose exec frontend npm install
+	@echo "Preparing WXT (generating .wxt/tsconfig.json) in worktree..."
+	@$(_load-env-exec) docker compose exec frontend npx wxt prepare
+	@echo ""
+	@echo "Worktree $(BRANCH) initialization complete!"
+	@echo "The worktree is ready for development."
+	@echo ""
+	@echo "To start development:"
+	@echo "  make wt-dev BRANCH=$(BRANCH)"
+
 wt-down:
 	@$(_load-env-exec) docker compose down || true
 
@@ -79,7 +107,8 @@ wt-up:
 	@$(_load-env-exec) docker compose up -d
 
 wt-dev: _wt-check-branch
-	@$(MAKE) _wt-check-exists BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-add BRANCH="$(BRANCH)"
+	@# Check if initialized for this branch, if not initialize it (which also creates worktree if needed)
+	@$(MAKE) _wt-check-initialized BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-init BRANCH="$(BRANCH)"
 	@$(MAKE) _wt-dev-in-worktree BRANCH="$(BRANCH)"
 
 wt-disable:

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -46,7 +46,7 @@ wt-init: _wt-check-branch
 	@$(MAKE) _wt-check-exists BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-add BRANCH="$(BRANCH)"
 	@echo "Initializing worktree for development: $(BRANCH)..."
 	@echo "Switching to worktree for initialization..."
-	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
+	@$(MAKE) _wt-create-override BRANCH="$(BRANCH)"
 	@echo "Stopping existing Docker services..."
 	@$(MAKE) wt-down
 	@echo "Starting Docker services for worktree..."

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -20,7 +20,7 @@ wt-list:
 
 wt-remove: _wt-check-branch
 	@echo "Removing worktree for branch: $(BRANCH)..."
-	@git worktree remove "$(WORKTREE_PATH)" --force 2>/dev/null || echo "Worktree not found: $(WORKTREE_PATH)"
+	@git worktree remove $(WORKTREE_PATH) --force 2>/dev/null || echo "Worktree not found: $(WORKTREE_PATH)"
 	@echo "Worktree removed"
 
 wt-prune:
@@ -46,7 +46,7 @@ wt-init: _wt-check-branch
 	@$(MAKE) _wt-check-exists BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-add BRANCH="$(BRANCH)"
 	@echo "Initializing worktree for development: $(BRANCH)..."
 	@echo "Switching to worktree for initialization..."
-	@$(MAKE) _wt-create-override BRANCH="$(BRANCH)"
+	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
 	@echo "Stopping existing Docker services..."
 	@$(MAKE) wt-down
 	@echo "Starting Docker services for worktree..."

--- a/make/worktree/main.mk
+++ b/make/worktree/main.mk
@@ -20,7 +20,7 @@ wt-list:
 
 wt-remove: _wt-check-branch
 	@echo "Removing worktree for branch: $(BRANCH)..."
-	@git worktree remove $(WORKTREE_PATH) --force 2>/dev/null || echo "Worktree not found: $(WORKTREE_PATH)"
+	@git worktree remove "$(WORKTREE_PATH)" --force 2>/dev/null || echo "Worktree not found: $(WORKTREE_PATH)"
 	@echo "Worktree removed"
 
 wt-prune:
@@ -46,7 +46,7 @@ wt-init: _wt-check-branch
 	@$(MAKE) _wt-check-exists BRANCH="$(BRANCH)" 2>/dev/null || $(MAKE) wt-add BRANCH="$(BRANCH)"
 	@echo "Initializing worktree for development: $(BRANCH)..."
 	@echo "Switching to worktree for initialization..."
-	@$(MAKE) _wt-create-override BRANCH=$(BRANCH)
+	@$(MAKE) _wt-create-override BRANCH="$(BRANCH)"
 	@echo "Stopping existing Docker services..."
 	@$(MAKE) wt-down
 	@echo "Starting Docker services for worktree..."

--- a/make/worktree/wt-add.mk
+++ b/make/worktree/wt-add.mk
@@ -1,9 +1,10 @@
 # Git Worktree Add Command
 # Creates a new worktree for a branch (file copy only, no Docker)
+# Note: BRANCH is validated by _wt-check-branch to contain only safe characters
 
 wt-add: _wt-check-branch
 	@echo "Creating worktree for branch: $(BRANCH)..."
-	@mkdir -p $(dir $(WORKTREE_PATH))
+	@mkdir -p "$(dir $(WORKTREE_PATH))"
 	@# Check write permissions on parent directory
 	@if ! touch "$(dir $(WORKTREE_PATH)).write_test" 2>/dev/null; then \
 		echo "Error: Cannot write to $(dir $(WORKTREE_PATH))"; \
@@ -19,21 +20,21 @@ wt-add: _wt-check-branch
 		exit 1; \
 	fi
 	@# Remove any orphaned directory
-	@$(MAKE) _wt-remove-orphaned BRANCH=$(BRANCH) 2>/dev/null || true
+	@$(MAKE) _wt-remove-orphaned BRANCH="$(BRANCH)" 2>/dev/null || true
 	@# Check if branch exists locally
-	@if git show-ref --verify --quiet refs/heads/$(BRANCH); then \
+	@if git show-ref --verify --quiet "refs/heads/$(BRANCH)"; then \
 		echo "Using existing local branch: $(BRANCH)"; \
-		git worktree add $(WORKTREE_PATH) $(BRANCH); \
-	elif git ls-remote --exit-code --heads origin $(BRANCH) >/dev/null 2>&1; then \
+		git worktree add "$(WORKTREE_PATH)" "$(BRANCH)"; \
+	elif git ls-remote --exit-code --heads origin "$(BRANCH)" >/dev/null 2>&1; then \
 		echo "Creating local branch from remote: origin/$(BRANCH)"; \
-		git worktree add --track -b $(BRANCH) $(WORKTREE_PATH) origin/$(BRANCH); \
+		git worktree add --track -b "$(BRANCH)" "$(WORKTREE_PATH)" "origin/$(BRANCH)"; \
 	else \
 		echo "Creating new branch: $(BRANCH)"; \
-		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
+		git worktree add -b "$(BRANCH)" "$(WORKTREE_PATH)"; \
 	fi
 	@echo "Worktree created at: $(WORKTREE_PATH)"
 	@echo "Setting up environment files..."
-	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
+	@$(MAKE) _wt-setup-env BRANCH="$(BRANCH)"
 	@echo ""
 	@echo "Worktree $(BRANCH) is ready."
 	@echo "To initialize for development (Docker, npm install, wxt prepare):"

--- a/make/worktree/wt-add.mk
+++ b/make/worktree/wt-add.mk
@@ -1,10 +1,9 @@
 # Git Worktree Add Command
 # Creates a new worktree for a branch (file copy only, no Docker)
-# Note: BRANCH is validated by _wt-check-branch to contain only safe characters
 
 wt-add: _wt-check-branch
 	@echo "Creating worktree for branch: $(BRANCH)..."
-	@mkdir -p "$(dir $(WORKTREE_PATH))"
+	@mkdir -p $(dir $(WORKTREE_PATH))
 	@# Check write permissions on parent directory
 	@if ! touch "$(dir $(WORKTREE_PATH)).write_test" 2>/dev/null; then \
 		echo "Error: Cannot write to $(dir $(WORKTREE_PATH))"; \
@@ -20,21 +19,21 @@ wt-add: _wt-check-branch
 		exit 1; \
 	fi
 	@# Remove any orphaned directory
-	@$(MAKE) _wt-remove-orphaned BRANCH="$(BRANCH)" 2>/dev/null || true
+	@$(MAKE) _wt-remove-orphaned BRANCH=$(BRANCH) 2>/dev/null || true
 	@# Check if branch exists locally
-	@if git show-ref --verify --quiet "refs/heads/$(BRANCH)"; then \
+	@if git show-ref --verify --quiet refs/heads/$(BRANCH); then \
 		echo "Using existing local branch: $(BRANCH)"; \
-		git worktree add "$(WORKTREE_PATH)" "$(BRANCH)"; \
-	elif git ls-remote --exit-code --heads origin "$(BRANCH)" >/dev/null 2>&1; then \
+		git worktree add $(WORKTREE_PATH) $(BRANCH); \
+	elif git ls-remote --exit-code --heads origin $(BRANCH) >/dev/null 2>&1; then \
 		echo "Creating local branch from remote: origin/$(BRANCH)"; \
-		git worktree add --track -b "$(BRANCH)" "$(WORKTREE_PATH)" "origin/$(BRANCH)"; \
+		git worktree add --track -b $(BRANCH) $(WORKTREE_PATH) origin/$(BRANCH); \
 	else \
 		echo "Creating new branch: $(BRANCH)"; \
-		git worktree add -b "$(BRANCH)" "$(WORKTREE_PATH)"; \
+		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
 	fi
 	@echo "Worktree created at: $(WORKTREE_PATH)"
 	@echo "Setting up environment files..."
-	@$(MAKE) _wt-setup-env BRANCH="$(BRANCH)"
+	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
 	@echo ""
 	@echo "Worktree $(BRANCH) is ready."
 	@echo "To initialize for development (Docker, npm install, wxt prepare):"

--- a/make/worktree/wt-add.mk
+++ b/make/worktree/wt-add.mk
@@ -1,5 +1,11 @@
 # Git Worktree Add Command
 # Creates a new worktree for a branch (file copy only, no Docker)
+#
+# TODO: Security - Add branch name validation and quote shell variables
+# - Validate BRANCH against safe character set [A-Za-z0-9._/-] in _wt-check-branch
+# - Quote all variable references in shell commands to prevent injection
+# See: https://github.com/akAredminEogre/frog-frame-front/pull/241#discussion_r2608419943
+# See: https://github.com/akAredminEogre/frog-frame-front/pull/241#discussion_r2608585252
 
 wt-add: _wt-check-branch
 	@echo "Creating worktree for branch: $(BRANCH)..."
@@ -19,21 +25,21 @@ wt-add: _wt-check-branch
 		exit 1; \
 	fi
 	@# Remove any orphaned directory
-	@$(MAKE) _wt-remove-orphaned BRANCH=$(BRANCH) 2>/dev/null || true
+	@$(MAKE) _wt-remove-orphaned BRANCH="$(BRANCH)" 2>/dev/null || true
 	@# Check if branch exists locally
-	@if git show-ref --verify --quiet refs/heads/$(BRANCH); then \
+	@if git show-ref --verify --quiet "refs/heads/$(BRANCH)"; then \
 		echo "Using existing local branch: $(BRANCH)"; \
-		git worktree add $(WORKTREE_PATH) $(BRANCH); \
-	elif git ls-remote --exit-code --heads origin $(BRANCH) >/dev/null 2>&1; then \
+		git worktree add "$(WORKTREE_PATH)" "$(BRANCH)"; \
+	elif git ls-remote --exit-code --heads origin "$(BRANCH)" >/dev/null 2>&1; then \
 		echo "Creating local branch from remote: origin/$(BRANCH)"; \
-		git worktree add --track -b $(BRANCH) $(WORKTREE_PATH) origin/$(BRANCH); \
+		git worktree add --track -b "$(BRANCH)" "$(WORKTREE_PATH)" "origin/$(BRANCH)"; \
 	else \
 		echo "Creating new branch: $(BRANCH)"; \
-		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
+		git worktree add -b "$(BRANCH)" "$(WORKTREE_PATH)"; \
 	fi
 	@echo "Worktree created at: $(WORKTREE_PATH)"
 	@echo "Setting up environment files..."
-	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
+	@$(MAKE) _wt-setup-env BRANCH="$(BRANCH)"
 	@echo ""
 	@echo "Worktree $(BRANCH) is ready."
 	@echo "To initialize for development (Docker, npm install, wxt prepare):"

--- a/make/worktree/wt-add.mk
+++ b/make/worktree/wt-add.mk
@@ -1,0 +1,43 @@
+# Git Worktree Add Command
+# Creates a new worktree for a branch (file copy only, no Docker)
+
+wt-add: _wt-check-branch
+	@echo "Creating worktree for branch: $(BRANCH)..."
+	@mkdir -p $(dir $(WORKTREE_PATH))
+	@# Check write permissions on parent directory
+	@if ! touch "$(dir $(WORKTREE_PATH)).write_test" 2>/dev/null; then \
+		echo "Error: Cannot write to $(dir $(WORKTREE_PATH))"; \
+		echo "The directory may have been created by Docker with root permissions."; \
+		echo "Please fix permissions with: sudo chown -R $$(whoami) $(WORKTREE_DIR)/"; \
+		exit 1; \
+	fi
+	@rm -f "$(dir $(WORKTREE_PATH)).write_test"
+	@# Check if worktree already exists in git
+	@if git worktree list | awk '{print $$1}' | grep -q "^$(PWD)/$(WORKTREE_PATH)\$$"; then \
+		echo "Error: Worktree already exists at $(WORKTREE_PATH)"; \
+		echo "To remove it, run: make wt-remove BRANCH=$(BRANCH)"; \
+		exit 1; \
+	fi
+	@# Remove any orphaned directory
+	@$(MAKE) _wt-remove-orphaned BRANCH=$(BRANCH) 2>/dev/null || true
+	@# Check if branch exists locally
+	@if git show-ref --verify --quiet refs/heads/$(BRANCH); then \
+		echo "Using existing local branch: $(BRANCH)"; \
+		git worktree add $(WORKTREE_PATH) $(BRANCH); \
+	elif git ls-remote --exit-code --heads origin $(BRANCH) >/dev/null 2>&1; then \
+		echo "Creating local branch from remote: origin/$(BRANCH)"; \
+		git worktree add --track -b $(BRANCH) $(WORKTREE_PATH) origin/$(BRANCH); \
+	else \
+		echo "Creating new branch: $(BRANCH)"; \
+		git worktree add -b $(BRANCH) $(WORKTREE_PATH); \
+	fi
+	@echo "Worktree created at: $(WORKTREE_PATH)"
+	@echo "Setting up environment files..."
+	@$(MAKE) _wt-setup-env BRANCH=$(BRANCH)
+	@echo ""
+	@echo "Worktree $(BRANCH) is ready."
+	@echo "To initialize for development (Docker, npm install, wxt prepare):"
+	@echo "  make wt-init BRANCH=$(BRANCH)"
+	@echo ""
+	@echo "Or start development directly (auto-initializes if needed):"
+	@echo "  make wt-dev BRANCH=$(BRANCH)"

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -2,6 +2,11 @@
 
 # Branch completion main entry point
 # This file is sourced by scripts/worktree/main.sh
+#
+# TODO: Security - Filter/escape branch names before completion
+# - Filter branch names to safe character set [A-Za-z0-9._/-]
+# - Or escape metacharacters using printf '%q' or proper shell quoting
+# See: https://github.com/akAredminEogre/frog-frame-front/pull/241#discussion_r2608634992
 
 # Get the directory where this script is located
 COMPLETION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -29,7 +29,7 @@ _WT_COMPLETION_DEFS=(
     "wt-add=_wt_get_all_branches"
     "wt-init=_wt_get_all_branches"
     "wt-remove=_wt_get_worktrees"
-    "wt-dev=_wt_get_worktrees"
+    "wt-dev=_wt_get_all_branches"
     "wt-cd=_wt_get_worktrees"
 )
 

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -27,6 +27,7 @@ _wt_get_worktrees() {
 # Add new commands here to enable completion
 _WT_COMPLETION_DEFS=(
     "wt-add=_wt_get_all_branches"
+    "wt-init=_wt_get_all_branches"
     "wt-remove=_wt_get_worktrees"
     "wt-dev=_wt_get_worktrees"
     "wt-cd=_wt_get_worktrees"

--- a/scripts/worktree/check_logic.sh
+++ b/scripts/worktree/check_logic.sh
@@ -2,6 +2,11 @@
 
 # Worktree check logic functions
 # This file provides common validation functions for worktree operations
+#
+# TODO: Security - Add branch name validation
+# - Validate branch names against safe character set [A-Za-z0-9._/-]
+# - Apply proper quoting/escaping to prevent shell injection
+# See: https://github.com/akAredminEogre/frog-frame-front/pull/241#discussion_r2608585266
 
 # Get script directory and source repository path helper
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/worktree/main.sh
+++ b/scripts/worktree/main.sh
@@ -89,5 +89,16 @@ wt-dev() {
     make -C "$REPO_ROOT" wt-dev BRANCH="$BRANCH"
 }
 
+# wt-init: Initialize worktree for development
+# Usage: wt-init <branch-name>
+wt-init() {
+    local BRANCH="$1"
+    if [ -z "$BRANCH" ]; then
+        echo "Usage: wt-init <branch-name>"
+        return 1
+    fi
+    make -C "$REPO_ROOT" wt-init BRANCH="$BRANCH"
+}
+
 # Source branch completion functions
 source "$SCRIPT_DIR/branch-completion/main.sh"


### PR DESCRIPTION
- wt-add: now only creates worktree and copies config files (no Docker)
- wt-init: new public command for Docker setup, npm install, wxt prepare
  - auto-calls wt-add if worktree doesn't exist
- wt-dev: calls wt-init if not initialized for the target branch

This separation allows:
- Lightweight worktree creation without Docker overhead
- Explicit control over initialization timing
- wt-dev remains the recommended all-in-one command