### PR TITLE
Show claude/ branches in command suggestions

### DIFF
--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -21,21 +21,17 @@ _wt_get_all_branches() {
 }
 
 # Get list of existing worktrees
-# Finds directories containing .git file (worktree marker) and returns relative paths
+# Uses git worktree list to find worktrees in the worktrees/ directory
 _wt_get_worktrees() {
     local worktree_dir="$REPO_ROOT/worktrees"
     if [ ! -d "$worktree_dir" ]; then
         return
     fi
 
-    # Find directories with .git file (worktree marker) and extract branch names
-    find "$worktree_dir" -name ".git" -type f 2>/dev/null | while read -r git_file; do
-        # Get the directory containing .git file and make it relative to worktree_dir
-        local worktree_path
-        worktree_path="$(dirname "$git_file")"
-        # Remove the worktree_dir prefix to get the branch name
-        echo "${worktree_path#$worktree_dir/}"
-    done
+    # Use git worktree list and filter those in worktrees/ directory
+    git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
+        grep "^worktree $worktree_dir/" | \
+        sed "s|^worktree $worktree_dir/||"
 }
 
 # Completion definitions: command=source_function

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -24,16 +24,18 @@ _wt_get_all_branches() {
 # Finds directories containing .git file (worktree marker) and returns relative paths
 _wt_get_worktrees() {
     local worktree_dir="$REPO_ROOT/worktrees"
-    if [ -d "$worktree_dir" ]; then
-        # Find directories with .git file (worktree marker) and extract branch names
-        find "$worktree_dir" -name ".git" -type f 2>/dev/null | while read -r git_file; do
-            # Get the directory containing .git file and make it relative to worktree_dir
-            local worktree_path
-            worktree_path="$(dirname "$git_file")"
-            # Remove the worktree_dir prefix to get the branch name
-            echo "${worktree_path#$worktree_dir/}"
-        done
+    if [ ! -d "$worktree_dir" ]; then
+        return
     fi
+
+    # Find directories with .git file (worktree marker) and extract branch names
+    find "$worktree_dir" -name ".git" -type f 2>/dev/null | while read -r git_file; do
+        # Get the directory containing .git file and make it relative to worktree_dir
+        local worktree_path
+        worktree_path="$(dirname "$git_file")"
+        # Remove the worktree_dir prefix to get the branch name
+        echo "${worktree_path#$worktree_dir/}"
+    done
 }
 
 # Completion definitions: command=source_function

--- a/scripts/worktree/branch-completion/main.sh
+++ b/scripts/worktree/branch-completion/main.sh
@@ -21,10 +21,18 @@ _wt_get_all_branches() {
 }
 
 # Get list of existing worktrees
+# Finds directories containing .git file (worktree marker) and returns relative paths
 _wt_get_worktrees() {
     local worktree_dir="$REPO_ROOT/worktrees"
     if [ -d "$worktree_dir" ]; then
-        ls -1 "$worktree_dir" 2>/dev/null
+        # Find directories with .git file (worktree marker) and extract branch names
+        find "$worktree_dir" -name ".git" -type f 2>/dev/null | while read -r git_file; do
+            # Get the directory containing .git file and make it relative to worktree_dir
+            local worktree_path
+            worktree_path="$(dirname "$git_file")"
+            # Remove the worktree_dir prefix to get the branch name
+            echo "${worktree_path#$worktree_dir/}"
+        done
     fi
 }
 


### PR DESCRIPTION
Update _wt_get_worktrees() to use find command to detect worktrees by looking for .git files (worktree markers), enabling proper completion for branch names containing slashes (e.g., claude/*)