### PR TITLE
Fix Vitest module resolution in VSCode worktree

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -10,10 +10,15 @@
 # the default value from .env to correctly mount the worktree's source directory.
 # This allows node_modules and .wxt/tsconfig.json generated inside the container
 # to be visible on the host side, enabling VSCode to resolve module imports.
+#
+# IMPORTANT: Both .env and .env.worktree are listed explicitly to ensure proper
+# variable override order. Docker Compose reads env_file entries in order, so
+# .env.worktree values (like HOST_FRONTEND_ROOT_PATH) will override .env values.
 
 services:
   frontend:
     env_file:
+      - .env
       - .env.worktree
     environment:
       # Tracking variable to identify worktree usage

--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -50,7 +50,7 @@ _wt-copy-override-template:
 
 # Create docker-compose.override.yml with worktree-specific volume mount
 # Note: We write the volume mount path directly to avoid Docker Compose variable
-# interpolation issues. The CONTAINER_APP_ROOT is read from .env to stay in sync.
+# interpolation issues. The CONTAINER_APP_ROOT is retrieved via get_container_app_root helper.
 _wt-create-override:
 	@$(MAKE) -s _wt-copy-override-template
 	@echo "Setting worktree environment variables..."
@@ -60,7 +60,7 @@ _wt-create-override:
 	@echo "# Override HOST_FRONTEND_ROOT_PATH to mount worktree source directory" >> .env.worktree
 	@echo "HOST_FRONTEND_ROOT_PATH=./$(WORKTREE_PATH)/host-frontend-root" >> .env.worktree
 	@echo "Adding volume mount for worktree to docker-compose.override.yml..."
-	@CONTAINER_ROOT=$$(grep '^CONTAINER_APP_ROOT=' .env 2>/dev/null | cut -d'=' -f2 || grep '^CONTAINER_APP_ROOT=' .env.example 2>/dev/null | cut -d'=' -f2); \
-	if [ -z "$$CONTAINER_ROOT" ]; then CONTAINER_ROOT="/opt/frontend-container-app-root"; fi; \
-	echo "    volumes:" >> docker-compose.override.yml; \
+	@source scripts/worktree/check_logic.sh && \
+	CONTAINER_ROOT=$$(get_container_app_root) && \
+	echo "    volumes:" >> docker-compose.override.yml && \
 	echo "      - ./$(WORKTREE_PATH)/host-frontend-root:$$CONTAINER_ROOT/" >> docker-compose.override.yml

--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -48,7 +48,9 @@ _wt-copy-override-template:
 	fi
 	@cp docker-compose.override.yml.example docker-compose.override.yml
 
-# Create docker-compose.override.yml
+# Create docker-compose.override.yml with worktree-specific volume mount
+# Note: We write the volume mount path directly to avoid Docker Compose variable
+# interpolation issues. The CONTAINER_APP_ROOT is read from .env to stay in sync.
 _wt-create-override:
 	@$(MAKE) -s _wt-copy-override-template
 	@echo "Setting worktree environment variables..."
@@ -57,3 +59,8 @@ _wt-create-override:
 	@echo "WORKTREE_ACTIVE_BRANCH=$(BRANCH)" >> .env.worktree
 	@echo "# Override HOST_FRONTEND_ROOT_PATH to mount worktree source directory" >> .env.worktree
 	@echo "HOST_FRONTEND_ROOT_PATH=./$(WORKTREE_PATH)/host-frontend-root" >> .env.worktree
+	@echo "Adding volume mount for worktree to docker-compose.override.yml..."
+	@CONTAINER_ROOT=$$(grep '^CONTAINER_APP_ROOT=' .env 2>/dev/null | cut -d'=' -f2 || grep '^CONTAINER_APP_ROOT=' .env.example 2>/dev/null | cut -d'=' -f2); \
+	if [ -z "$$CONTAINER_ROOT" ]; then CONTAINER_ROOT="/opt/frontend-container-app-root"; fi; \
+	echo "    volumes:" >> docker-compose.override.yml; \
+	echo "      - ./$(WORKTREE_PATH)/host-frontend-root:$$CONTAINER_ROOT/" >> docker-compose.override.yml

--- a/scripts/worktree/check_logic.sh
+++ b/scripts/worktree/check_logic.sh
@@ -62,19 +62,15 @@ get_container_app_root() {
     # Try .env first
     if check_env_exists; then
         container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env" | cut -d'=' -f2)
-        if [ -n "$container_root" ]; then
-            echo "$container_root"
-            return 0
-        fi
+        echo "$container_root"
+        return 0
     fi
 
     # Try .env.example
     if check_env_example_exists; then
         container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env.example" | cut -d'=' -f2)
-        if [ -n "$container_root" ]; then
-            echo "$container_root"
-            return 0
-        fi
+        echo "$container_root"
+        return 0
     fi
 
     # Fallback to default

--- a/scripts/worktree/check_logic.sh
+++ b/scripts/worktree/check_logic.sh
@@ -25,6 +25,18 @@ check_env_worktree_exists() {
     return 0
 }
 
+# Check if .env file exists
+# Returns: 0 if exists, 1 if not exists
+check_env_exists() {
+    [ -f "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env" ]
+}
+
+# Check if .env.example file exists
+# Returns: 0 if exists, 1 if not exists
+check_env_example_exists() {
+    [ -f "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env.example" ]
+}
+
 # Get active branch from .env.worktree and validate it's not empty
 # Outputs: branch name to stdout if valid
 # Returns: 0 if valid, 1 if empty/invalid (with error message)
@@ -45,15 +57,27 @@ get_and_check_active_branch() {
 # Returns: 0 always (uses default if not found)
 get_container_app_root() {
     local container_root
-    # Try .env first, then .env.example
-    container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env" 2>/dev/null | cut -d'=' -f2)
-    if [ -z "$container_root" ]; then
-        container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env.example" 2>/dev/null | cut -d'=' -f2)
+    local default_value="/opt/frontend-container-app-root"
+
+    # Try .env first
+    if check_env_exists; then
+        container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env" | cut -d'=' -f2)
+        if [ -n "$container_root" ]; then
+            echo "$container_root"
+            return 0
+        fi
     fi
-    # Use default if still not found
-    if [ -z "$container_root" ]; then
-        container_root="/opt/frontend-container-app-root"
+
+    # Try .env.example
+    if check_env_example_exists; then
+        container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env.example" | cut -d'=' -f2)
+        if [ -n "$container_root" ]; then
+            echo "$container_root"
+            return 0
+        fi
     fi
-    echo "$container_root"
+
+    # Fallback to default
+    echo "$default_value"
     return 0
 }

--- a/scripts/worktree/check_logic.sh
+++ b/scripts/worktree/check_logic.sh
@@ -39,3 +39,21 @@ get_and_check_active_branch() {
     echo "$branch"
     return 0
 }
+
+# Get CONTAINER_APP_ROOT from .env or .env.example, with fallback to default
+# Outputs: CONTAINER_APP_ROOT path to stdout
+# Returns: 0 always (uses default if not found)
+get_container_app_root() {
+    local container_root
+    # Try .env first, then .env.example
+    container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env" 2>/dev/null | cut -d'=' -f2)
+    if [ -z "$container_root" ]; then
+        container_root=$(grep '^CONTAINER_APP_ROOT=' "$_REPOSITORY_TOP_ABSOLUTE_PATH/.env.example" 2>/dev/null | cut -d'=' -f2)
+    fi
+    # Use default if still not found
+    if [ -z "$container_root" ]; then
+        container_root="/opt/frontend-container-app-root"
+    fi
+    echo "$container_root"
+    return 0
+}


### PR DESCRIPTION
worktreeでの開発時に、VS Codeで「モジュール 'vitest' またはそれに対応する
型宣言が見つかりません」等のエラーが表示される問題を修正。

根本原因:
Docker Composeの変数補間は、env_fileからではなくシェル環境変数と.envファイル から行われるため、.env.worktreeのHOST_FRONTEND_ROOT_PATHがボリュームマウント 設定に正しく反映されていなかった。

変更内容:
- docker-compose.override.yml.example: .envと.env.worktreeの両方を明示的に env_fileに指定し、環境変数の上書き順序を明確化
- init-worktree-helper.mk: _wt-create-overrideでworktreeのボリュームマウント パスをdocker-compose.override.ymlに直接書き込むように変更

これにより、worktree初期化時にdocker-compose.override.ymlに正しいパスが 設定され、コンテナで生成されたnode_modulesと.wxt/tsconfig.jsonがホスト側に 反映される。