### PR TITLE
Fix VS Code trust prompt in worktree

### DIFF
--- a/make/worktree/helpers/init-worktree-helper.mk
+++ b/make/worktree/helpers/init-worktree-helper.mk
@@ -38,6 +38,10 @@ _wt-setup-env:
 			echo "Copied matchUrl.ts.example to worktree as matchUrl.ts"; \
 		fi \
 	fi
+	@if [ -d .claude ]; then \
+		cp -r .claude $(WORKTREE_PATH)/.claude; \
+		echo "Copied .claude/ to worktree"; \
+	fi
 
 # Internal helper: Copy override template to docker-compose.override.yml
 _wt-copy-override-template:


### PR DESCRIPTION
When creating a worktree, the .claude/ directory is now copied so Claude Code recognizes the worktree as trusted and does not show the "Do you trust the files in this folder?" prompt.