### PR TITLE
Remove unused exported type interfaces

### DIFF
--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/messaging/messaging.ts
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/messaging/messaging.ts
@@ -6,7 +6,7 @@ import { defineExtensionMessaging } from '@webext-core/messaging';
  *
  * Note: getAllRules は @webext-core/proxy-service (RewriteRuleProxyService) に移行済み
  */
-export interface BackgroundProtocolMap {
+interface BackgroundProtocolMap {
   /**
    * 全ルールを適用する
    * Popup → Background
@@ -18,7 +18,7 @@ export interface BackgroundProtocolMap {
  * Content Script へのメッセージプロトコル定義
  * Background から Content Script へ送信するメッセージ
  */
-export interface ContentScriptProtocolMap {
+interface ContentScriptProtocolMap {
   /**
    * ルールを適用する
    * Background → Content Script

--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch.tsx
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch.tsx
@@ -9,7 +9,7 @@ import styles from 'src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch.
 /**
  * ToggleSwitchコンポーネントのProps
  */
-export interface ToggleSwitchProps {
+interface ToggleSwitchProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/ui/components/atoms/ToggleSwitch/test-helpers.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/ui/components/atoms/ToggleSwitch/test-helpers.tsx
@@ -6,7 +6,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { vi } from 'vitest';
 
-import { ToggleSwitch, ToggleSwitchProps } from 'src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch';
+import { ToggleSwitch } from 'src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch';
+
+type ToggleSwitchProps = React.ComponentProps<typeof ToggleSwitch>;
 
 /**
  * React更新をフラッシュするためのユーティリティ


### PR DESCRIPTION
- BackgroundProtocolMap, ContentScriptProtocolMap: 内部使用のみのため export を削除
- ToggleSwitchProps: テストで React.ComponentProps を使用するよう変更