### PR TITLE
Fix isActive flag implementation

### DIFF
--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/persistence/ChromeRuntimeRewriteRuleRepository.ts
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/persistence/ChromeRuntimeRewriteRuleRepository.ts
@@ -77,7 +77,7 @@ export class ChromeRuntimeRewriteRuleRepository implements IRewriteRuleRepositor
    */
   async getRulesMatchingUrl(currentUrl: string): Promise<RewriteRules> {
     const allRules = await this.getAll();
-    const matchingRules = allRules.toArray().filter((rule) => rule.matchesUrl(currentUrl));
+    const matchingRules = allRules.toArray().filter((rule) => rule.isActive && rule.matchesUrl(currentUrl));
 
     const rulesObject: Record<string, RewriteRule> = {};
     matchingRules.forEach((rule) => {

--- a/host-frontend-root/frontend-src-root/src/infrastructure/persistence/indexeddb/DexieRewriteRuleRepository.ts
+++ b/host-frontend-root/frontend-src-root/src/infrastructure/persistence/indexeddb/DexieRewriteRuleRepository.ts
@@ -81,7 +81,7 @@ export class DexieRewriteRuleRepository implements IRewriteRuleRepository {
    */
   async getRulesMatchingUrl(currentUrl: string): Promise<RewriteRules> {
     const schemas = await this.database.rewriteRules
-      .filter(schema => currentUrl.startsWith(schema.urlPattern) && schema.urlPattern !== '')
+      .filter(schema => schema.isActive && currentUrl.startsWith(schema.urlPattern) && schema.urlPattern !== '')
       .toArray();
 
     const rulesObject: Record<string, RewriteRule> = {};


### PR DESCRIPTION
getRulesMatchingUrl()でURLマッチング時にisActiveフラグをチェックし、 非アクティブなルールを除外するように修正