### PR TITLE
Add IToggleRuleActiveController interface to formalize public API

### DIFF
--- a/docs/adr/001-clean-architecture-with-presenter-pattern.md
+++ b/docs/adr/001-clean-architecture-with-presenter-pattern.md
@@ -121,6 +121,8 @@ src/
 │   │   └── ToggleRuleActiveController.ts
 │   ├── presenters/                             ← Presenter
 │   │   └── ToggleRuleActivePresenter.ts
+│   ├── factories/                              ← Factory（ADR-005参照）
+│   │   └── ToggleRuleActiveControllerFactory.ts
 │   ├── ports/                                  ← Port（Mapperが依存、依存性逆転のため）
 │   │   └── IRewriteRuleMessagingPort.ts
 │   └── mappers/                                ← Mapper

--- a/docs/adr/005-factory-pattern-for-react-callback-injection.md
+++ b/docs/adr/005-factory-pattern-for-react-callback-injection.md
@@ -1,0 +1,92 @@
+# ADR-005: ReactコールバックをPresenterに注入するためのFactoryパターン採用
+
+## ステータス
+
+採用
+
+## コンテキスト
+
+Clean Architecture + Presenterパターン（ADR-001）では、Presenterが処理結果をViewに通知する。ReactコンポーネントをViewとして使用する場合、Presenterは `useState` から得られる状態更新関数（`setState`）を呼び出す必要がある。
+
+しかし、以下の制約がある：
+
+1. **DIコンテナのライフサイクル**: アプリ起動時に依存関係を解決する
+2. **Reactの状態関数のライフサイクル**: コンポーネントのレンダリング時に生成される
+
+この時間差により、DIコンテナだけではReactの状態更新関数をPresenterに注入できない。
+
+### 検討した代替案
+
+1. **状態変更のたびにDIコンテナで依存解決する方式**
+   - 毎回 `container.register()` でコールバックを登録し、`container.resolve()` でControllerを取得
+   - 問題点:
+     - グローバルなDIコンテナの状態を変更するため、他コンポーネントに影響する可能性
+     - 毎回resolve/スコープ生成のパフォーマンスオーバーヘッド
+     - コンポーネントがDIコンテナのAPIを直接知る必要がある（関心の分離の違反）
+     - React Strictモードでの2回レンダリングによる予期しない動作の可能性
+
+## 決定
+
+### Factoryパターンによる2段階の依存性注入
+
+1. **起動時（DIコンテナ）**: Repository, Gateway など技術的依存をFactoryに注入
+2. **レンダリング時（Factory.create）**: Reactコールバック（成功/エラー時の状態更新関数）をPresenterに注入
+
+```
+DIコンテナ（起動時）          Reactコンポーネント（レンダリング時）
+       │                              │
+       ▼                              ▼
+ ┌─────────────────┐           ┌──────────────┐
+ │ Factory         │           │ setState     │
+ │ (repository,    │◄──────────│ callbacks    │
+ │  tabsGateway)   │           └──────────────┘
+ └────────┬────────┘
+          │ create(onSuccess, onError)
+          ▼
+ ┌─────────────────┐
+ │ Controller      │
+ │ + Presenter     │
+ │ + Interactor    │
+ └─────────────────┘
+```
+
+### Factoryの責務
+
+- DIコンテナから受け取った依存（Repository, Gateway）を保持
+- `create()` 呼び出し時にコールバックを受け取り、Presenter/Interactor/Controllerを生成
+- 生成したControllerを返却
+
+### Presenterの責務
+
+- UseCaseの出力データをViewが使える形に変換（値の調整）
+- 成功/失敗に応じて適切なコールバックを呼び出す（出力先の選択）
+
+### コンポーネント側のメリット
+
+- `try-catch` による成功/失敗の分岐が不要
+- DIコンテナのAPIを直接知る必要がない
+- Controllerのメソッドを呼ぶだけで、結果は自動的にコールバック経由で通知される
+
+## 理由
+
+1. **関心の分離**: Factoryが「DIの世界」と「Reactの世界」の境界を明確に分離する
+2. **テスト容易性**: Factory自体はDIコンテナでモック可能、コールバックも任意の関数を渡せる
+3. **React Strictモードとの互換性**: グローバルなDIコンテナ状態を変更しないため、2回レンダリングでも安全
+4. **シンプルさ**: コンポーネントはFactoryの `create()` を呼ぶだけでよい
+
+### トレードオフ
+
+- Presenter/Interactor/ControllerはDIコンテナの恩恵（自動解決、ライフサイクル管理）を受けられない
+- Factory内で毎回 `new` するため、これらのオブジェクトはリクエストごとに新規生成される
+
+このトレードオフは、Reactとの統合のしやすさを優先した妥協点として許容する。
+
+## 影響ドキュメント
+
+このADRが変更された場合、以下のドキュメントも更新が必要：
+
+- [001-clean-architecture-with-presenter-pattern.md](001-clean-architecture-with-presenter-pattern.md)
+
+## 関連ドキュメント
+
+- [ADR-001: Clean Architecture Presenter付きパターン採用](001-clean-architecture-with-presenter-pattern.md)

--- a/docs/design/pages/rule-list/features/toggle-rule-active/01-class-design.md
+++ b/docs/design/pages/rule-list/features/toggle-rule-active/01-class-design.md
@@ -242,16 +242,16 @@ ADR-001 に従い、ドメインエンティティの値を用いた判定・計
 │                                                                             │
 │  ┌─────────────────────────────┐    ┌─────────────────────────────┐        │
 │  │ <<interface>>               │    │ <<interface>>               │        │
-│  │ IToggleRuleActiveController │    │ IToggleRuleActiveController │        │
-│  │ Factory                     │    │                             │        │
+│  │ IToggleRuleActive           │    │ IToggleRuleActiveController │        │
+│  │ ControllerFactory           │    │                             │        │
 │  │ ─────────────────────────── │    │ ─────────────────────────── │        │
 │  │ + create(onSuccess,         │    │ + toggleActive(ruleId)      │        │
 │  │   onError): IToggle...Ctrl  │    └──────────▲──────────────────┘        │
 │  └──────────▲──────────────────┘               │ implements                │
 │             │ implements                       │                           │
 │  ┌──────────┴──────────────────┐    ┌──────────┴──────────────────┐        │
-│  │ ToggleRuleActiveController  │    │ ToggleRuleActiveController  │        │
-│  │ Factory                     │    │ ─────────────────────────── │        │
+│  │ ToggleRuleActive            │    │ ToggleRuleActiveController  │        │
+│  │ ControllerFactory           │    │ ─────────────────────────── │        │
 │  │ ─────────────────────────── │    │ - useCase: IToggleRule...   │        │
 │  │ - repository: IRewriteRule..│    │ ─────────────────────────── │        │
 │  │ - tabsGateway: ITabsGateway │    │ + toggleActive(ruleId)      │        │

--- a/docs/design/pages/rule-list/features/toggle-rule-active/01-class-design.md
+++ b/docs/design/pages/rule-list/features/toggle-rule-active/01-class-design.md
@@ -77,8 +77,11 @@
 
 | クラス | 責務 |
 |--------|------|
-| ToggleRuleActiveController | ユーザー入力をInputDataに変換 |
-| ToggleRuleActivePresenter | OutputDataをViewに通知 |
+| IToggleRuleActiveController | Controllerのインターフェース。Factoryの戻り値型として使用（ADR-005参照） |
+| ToggleRuleActiveController | IToggleRuleActiveControllerの実装。ユーザー入力をInputDataに変換 |
+| IToggleRuleActiveControllerFactory | Controllerを生成するFactoryのインターフェース。ReactコールバックをPresenterに注入（ADR-005参照） |
+| ToggleRuleActiveControllerFactory | IToggleRuleActiveControllerFactoryの実装 |
+| ToggleRuleActivePresenter | OutputDataをViewに通知
 | RewriteRuleMapper | Entity ↔ DTO 変換 + IRewriteRuleMessagingPort 経由で通信（ADR-002、ADR-003参照） |
 | IRewriteRuleMessagingPort | MessagingService の抽象化（Port） |
 
@@ -238,12 +241,31 @@ ADR-001 に従い、ドメインエンティティの値を用いた判定・計
 │                          interface-adapters/                                │
 │                                                                             │
 │  ┌─────────────────────────────┐    ┌─────────────────────────────┐        │
-│  │ ToggleRuleActiveController  │    │ ToggleRuleActivePresenter   │        │
+│  │ <<interface>>               │    │ <<interface>>               │        │
+│  │ IToggleRuleActiveController │    │ IToggleRuleActiveController │        │
+│  │ Factory                     │    │                             │        │
 │  │ ─────────────────────────── │    │ ─────────────────────────── │        │
-│  │ - useCase: IToggleRule...   │    │ - updateRuleInView: Func    │        │
-│  │ ─────────────────────────── │    │ ─────────────────────────── │        │
-│  │ + toggleActive(ruleId)      │    │ + present(outputData)       │        │
-│  └─────────────────────────────┘    └─────────────────────────────┘        │
+│  │ + create(onSuccess,         │    │ + toggleActive(ruleId)      │        │
+│  │   onError): IToggle...Ctrl  │    └──────────▲──────────────────┘        │
+│  └──────────▲──────────────────┘               │ implements                │
+│             │ implements                       │                           │
+│  ┌──────────┴──────────────────┐    ┌──────────┴──────────────────┐        │
+│  │ ToggleRuleActiveController  │    │ ToggleRuleActiveController  │        │
+│  │ Factory                     │    │ ─────────────────────────── │        │
+│  │ ─────────────────────────── │    │ - useCase: IToggleRule...   │        │
+│  │ - repository: IRewriteRule..│    │ ─────────────────────────── │        │
+│  │ - tabsGateway: ITabsGateway │    │ + toggleActive(ruleId)      │        │
+│  │ ─────────────────────────── │    └─────────────────────────────┘        │
+│  │ + create(onSuccess,         │                                           │
+│  │   onError): IToggle...Ctrl  │    ┌─────────────────────────────┐        │
+│  └─────────────────────────────┘    │ ToggleRuleActivePresenter   │        │
+│                                     │ ─────────────────────────── │        │
+│                                     │ - updateRuleInView: Func    │        │
+│                                     │ - showErrorInView: Func     │        │
+│                                     │ ─────────────────────────── │        │
+│                                     │ + present(outputData)       │        │
+│                                     │ + presentError(errorData)   │        │
+│                                     └─────────────────────────────┘        │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/design/pages/rule-list/features/toggle-rule-active/02-sequence.puml
+++ b/docs/design/pages/rule-list/features/toggle-rule-active/02-sequence.puml
@@ -8,6 +8,9 @@ box "Rules Page - UI" #LightBlue
 end box
 
 box "interface-adapters" #LightGreen
+  participant "<<interface>>\nIToggleRuleActiveControllerFactory" as IFactory
+  participant "ToggleRuleActiveControllerFactory" as Factory
+  participant "<<interface>>\nIToggleRuleActiveController" as IController
   participant "ToggleRuleActiveController" as Controller
   participant "ToggleRuleActivePresenter" as Presenter
   participant "RewriteRuleMapper" as Mapper
@@ -37,12 +40,37 @@ box "enterprise-business-rules" #LightPink
   participant "RewriteRule" as Entity
 end box
 
+== 初期化（useMemo内） ==
+
+View -> IFactory : create(onSuccess, onError)
+activate IFactory
+
+IFactory -> Factory : create(onSuccess, onError)
+activate Factory
+
+Factory -> Presenter : new(onSuccess, onError)
+Factory -> Interactor : new(repository, tabsGateway, presenter)
+Factory -> Controller : new(interactor)
+Factory --> IFactory : controller
+deactivate Factory
+
+IFactory --> View : controller
+deactivate IFactory
+
+note right of View
+  ADR-005: Factoryパターンにより
+  ReactコールバックをPresenterに注入
+end note
+
 == トグル操作 ==
 
 UI -> View : onToggle(ruleId)
 activate View
 
-View -> Controller : toggleActive(ruleId)
+View -> IController : toggleActive(ruleId)
+activate IController
+
+IController -> Controller : toggleActive(ruleId)
 activate Controller
 
 Controller -> Interactor : execute(inputData)
@@ -186,6 +214,7 @@ View --> UI : 状態更新
 deactivate Presenter
 deactivate Interactor
 deactivate Controller
+deactivate IController
 deactivate View
 
 @enduml

--- a/docs/design/pages/rule-list/features/toggle-rule-active/03-directory-structure.md
+++ b/docs/design/pages/rule-list/features/toggle-rule-active/03-directory-structure.md
@@ -37,9 +37,13 @@ src/application-business-rules/
 ```
 src/interface-adapters/
 ├── controllers/                                 ← Controller
+│   ├── IToggleRuleActiveController.ts           ← Controllerインターフェース（ADR-005参照）
 │   └── ToggleRuleActiveController.ts
 ├── presenters/                                  ← Presenter
 │   └── ToggleRuleActivePresenter.ts
+├── factories/                                   ← Factory（ADR-005参照）
+│   ├── IToggleRuleActiveControllerFactory.ts    ← FactoryインターフェースReactコールバック注入用
+│   └── ToggleRuleActiveControllerFactory.ts     ← Factory実装
 ├── ports/                                       ← Port（Mapperが依存、ADR-002参照）
 │   └── IRewriteRuleMessagingPort.ts             ← MessagingService の抽象化
 └── mappers/                                     ← Mapper（ADR-002、ADR-003参照）

--- a/docs/design/pages/rule-list/features/toggle-rule-active/04-class-diagram.puml
+++ b/docs/design/pages/rule-list/features/toggle-rule-active/04-class-diagram.puml
@@ -43,14 +43,30 @@ interface ITabsGateway <<Gateway Interface>> {
 }
 
 ' === Interface Adapters ===
+interface IToggleRuleActiveController <<Controller Interface>> {
+  + toggleActive(ruleId: number): Promise<void>
+}
+
 class ToggleRuleActiveController <<Controller>> {
   - useCase: IToggleRuleActiveUseCase
   + toggleActive(ruleId: number): Promise<void>
 }
 
+interface IToggleRuleActiveControllerFactory <<Factory Interface>> {
+  + create(onSuccess, onError): IToggleRuleActiveController
+}
+
+class ToggleRuleActiveControllerFactory <<Factory>> {
+  - repository: IRewriteRuleRepository
+  - tabsGateway: ITabsGateway
+  + create(onSuccess, onError): IToggleRuleActiveController
+}
+
 class ToggleRuleActivePresenter <<Presenter>> {
   - updateRuleInView: (rule: RewriteRule) => void
+  - showErrorInView: (ruleId: number, message: string) => void
   + present(outputData: ToggleRuleActiveOutputData): void
+  + presentError(errorData: ToggleRuleActiveErrorOutputData): void
 }
 
 class RewriteRuleMapper <<Mapper>> {
@@ -105,7 +121,13 @@ class UpdateRuleActiveRequestDTO <<DTO>> {
 }
 
 ' === Relationships ===
-RulesApp ..> ToggleRuleActiveController : uses
+RulesApp ..> IToggleRuleActiveControllerFactory : uses
+ToggleRuleActiveControllerFactory ..|> IToggleRuleActiveControllerFactory : implements
+ToggleRuleActiveControllerFactory ..> ToggleRuleActiveController : creates
+ToggleRuleActiveControllerFactory ..> ToggleRuleActivePresenter : creates
+ToggleRuleActiveControllerFactory ..> ToggleRuleActiveInteractor : creates
+ToggleRuleActiveController ..|> IToggleRuleActiveController : implements
+RulesApp ..> IToggleRuleActiveController : uses
 ToggleRuleActiveController ..> IToggleRuleActiveUseCase : uses
 ToggleRuleActiveInteractor ..|> IToggleRuleActiveUseCase : implements
 ToggleRuleActiveInteractor ..> ToggleRuleActiveInputData : uses

--- a/host-frontend-root/frontend-src-root/src/interface-adapters/controllers/IToggleRuleActiveController.ts
+++ b/host-frontend-root/frontend-src-root/src/interface-adapters/controllers/IToggleRuleActiveController.ts
@@ -1,0 +1,6 @@
+/**
+ * ルールの有効/無効切り替えControllerのインターフェース
+ */
+export interface IToggleRuleActiveController {
+  toggleActive(ruleId: number): Promise<void>;
+}

--- a/host-frontend-root/frontend-src-root/src/interface-adapters/controllers/ToggleRuleActiveController.ts
+++ b/host-frontend-root/frontend-src-root/src/interface-adapters/controllers/ToggleRuleActiveController.ts
@@ -1,10 +1,11 @@
 import { ToggleRuleActiveInputData } from 'src/application-business-rules/dto/input/ToggleRuleActiveInputData';
 import { IToggleRuleActiveUseCase } from 'src/application-business-rules/ports/input/IToggleRuleActiveUseCase';
+import { IToggleRuleActiveController } from 'src/interface-adapters/controllers/IToggleRuleActiveController';
 
 /**
  * ルールの有効/無効切り替えのController
  */
-export class ToggleRuleActiveController {
+export class ToggleRuleActiveController implements IToggleRuleActiveController {
   constructor(
     private readonly useCase: IToggleRuleActiveUseCase
   ) {}

--- a/host-frontend-root/frontend-src-root/src/interface-adapters/factories/IToggleRuleActiveControllerFactory.ts
+++ b/host-frontend-root/frontend-src-root/src/interface-adapters/factories/IToggleRuleActiveControllerFactory.ts
@@ -1,5 +1,5 @@
 import { RewriteRule } from 'src/enterprise-business-rules/entities/RewriteRule/RewriteRule';
-import { ToggleRuleActiveController } from 'src/interface-adapters/controllers/ToggleRuleActiveController';
+import { IToggleRuleActiveController } from 'src/interface-adapters/controllers/IToggleRuleActiveController';
 
 export type ToggleSuccessCallback = (rule: RewriteRule) => void;
 export type ToggleErrorCallback = (ruleId: number, message: string) => void;
@@ -8,5 +8,5 @@ export interface IToggleRuleActiveControllerFactory {
   create(
     onSuccess: ToggleSuccessCallback,
     onError: ToggleErrorCallback
-  ): ToggleRuleActiveController;
+  ): IToggleRuleActiveController;
 }

--- a/host-frontend-root/frontend-src-root/src/interface-adapters/factories/ToggleRuleActiveControllerFactory.ts
+++ b/host-frontend-root/frontend-src-root/src/interface-adapters/factories/ToggleRuleActiveControllerFactory.ts
@@ -1,6 +1,7 @@
 import { IRewriteRuleRepository } from 'src/application/ports/IRewriteRuleRepository';
 import { ToggleRuleActiveInteractor } from 'src/application-business-rules/interactors/ToggleRuleActiveInteractor';
 import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { IToggleRuleActiveController } from 'src/interface-adapters/controllers/IToggleRuleActiveController';
 import { ToggleRuleActiveController } from 'src/interface-adapters/controllers/ToggleRuleActiveController';
 import {
   IToggleRuleActiveControllerFactory,
@@ -15,7 +16,7 @@ export class ToggleRuleActiveControllerFactory implements IToggleRuleActiveContr
     private readonly tabsGateway: ITabsGateway
   ) {}
 
-  create(onSuccess: ToggleSuccessCallback, onError: ToggleErrorCallback): ToggleRuleActiveController {
+  create(onSuccess: ToggleSuccessCallback, onError: ToggleErrorCallback): IToggleRuleActiveController {
     const presenter = new ToggleRuleActivePresenter(onSuccess, onError);
     const interactor = new ToggleRuleActiveInteractor(this.repository, this.tabsGateway, presenter);
     return new ToggleRuleActiveController(interactor);


### PR DESCRIPTION
knipが検出したtoggleActiveメソッドの未使用警告を解決するため、
IToggleRuleActiveControllerインターフェースを作成し、
ファクトリの戻り値型を具象クラスからインターフェースに変更。