### PR TITLE
Implement and test P2-c3 presenter

### DIFF
--- a/docs/design/src/interface-adapters/presenters/DeleteRulePresenter/present.md
+++ b/docs/design/src/interface-adapters/presenters/DeleteRulePresenter/present.md
@@ -1,0 +1,66 @@
+# DeleteRulePresenter.present() テスト戦略
+
+## 目的
+
+OutputDataを受け取り、コールバック関数を呼び出してViewに削除成功を通知する。
+PresenterはOutputDataをViewに橋渡しする責務のみを持ち、データ変換ロジックは含まない。
+
+## テスト分類
+
+### 1. 正常系（コールバック呼び出しと引数検証）
+
+コールバック関数が正しく呼び出され、deletedRuleIdが正しく渡されることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| 任意のruleId | deletedRuleIdでremoveRuleFromViewコールバックが呼び出される | 削除成功通知の基本パターン |
+
+**対応テスト**: `normal-cases.test.ts`
+
+### 2. コールバック呼び出しの分離
+
+removeRuleFromViewのみが呼び出され、showErrorInViewは呼び出されないことを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| コールバック分離 | showErrorInViewが呼び出されない | 成功通知とエラー通知の責務分離 |
+
+**対応テスト**: `normal-cases.test.ts`（同一テスト内で検証）
+
+## 網羅性チェック
+
+- [x] removeRuleFromViewコールバックが呼び出されること
+- [x] コールバックにdeletedRuleIdが正しく渡されること
+- [x] showErrorInViewが呼び出されないこと
+- [ ] 異常系（コールバックが例外をスロー） → 不要（Presenterはエラーをキャッチせず呼び出し元に伝播）
+- [ ] OutputDataのバリデーション → 不要（責務外、OutputDataはInteractor層で生成）
+
+### 異常系テストが不要な理由
+
+PresenterはOutputDataを受け取りViewに通知するのみで、エラーハンドリングの責務を持たない：
+
+1. **責務の分離**: PresenterはOutputDataの橋渡しのみ、エラー処理はView層
+2. **エラー伝播**: コールバックからのエラーは呼び出し元（Interactor経由）に伝播
+3. **データ検証**: OutputDataの正当性はInteractor層で保証済み
+
+## テストファイル構成
+
+```
+tests/unit/interface-adapters/presenters/DeleteRulePresenter/present/
+└── normal-cases.test.ts       # コールバック呼び出し確認（配列ベース）
+```
+
+## モック戦略
+
+コンストラクタに渡すコールバック関数をvi.fn()でモック化してテストする。
+
+### モック対象
+
+| 依存関係 | モック方法 | 理由 |
+|---------|-----------|------|
+| removeRuleFromView | vi.fn() | 呼び出しと引数の検証 |
+| showErrorInView | vi.fn() | 呼び出されないことの確認 |
+
+### テストデータ
+
+DeleteRuleOutputDataは実インスタンスを使用。

--- a/docs/design/src/interface-adapters/presenters/DeleteRulePresenter/presentError.md
+++ b/docs/design/src/interface-adapters/presenters/DeleteRulePresenter/presentError.md
@@ -1,0 +1,69 @@
+# DeleteRulePresenter.presentError() テスト戦略
+
+## 目的
+
+ErrorOutputDataを受け取り、コールバック関数を呼び出してViewにエラー情報を通知する。
+PresenterはErrorOutputDataをViewに橋渡しする責務のみを持ち、データ変換ロジックは含まない。
+
+## テスト分類
+
+### 1. 正常系（コールバック呼び出しと引数検証）
+
+コールバック関数が正しく呼び出され、ruleIdとmessageが正しく渡されることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| Errorオブジェクト由来 | Errorオブジェクト由来のエラーでコールバック呼び出し＋引数検証 | 標準エラーの通知 |
+| 文字列由来 | 文字列由来のエラーでコールバック呼び出し＋引数検証 | 非標準エラーの通知 |
+
+**対応テスト**: `normal-cases.test.ts`
+
+### 2. コールバック呼び出しの分離
+
+showErrorInViewのみが呼び出され、removeRuleFromViewは呼び出されないことを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| コールバック分離 | removeRuleFromViewが呼び出されない | エラー通知とルール削除の責務分離 |
+
+**対応テスト**: `normal-cases.test.ts`（同一テスト内で検証）
+
+## 網羅性チェック
+
+- [x] showErrorInViewコールバックが呼び出されること
+- [x] コールバックにruleIdが正しく渡されること
+- [x] コールバックにmessageが正しく渡されること
+- [x] removeRuleFromViewが呼び出されないこと
+- [x] Errorオブジェクト/文字列の両パターン
+- [ ] 異常系（コールバックが例外をスロー） → 不要（Presenterはエラーをキャッチせず呼び出し元に伝播）
+- [ ] ErrorOutputDataのバリデーション → 不要（責務外、ErrorOutputDataはInteractor層で生成）
+
+### 異常系テストが不要な理由
+
+PresenterはErrorOutputDataを受け取りViewに通知するのみで、エラーハンドリングの責務を持たない：
+
+1. **責務の分離**: PresenterはErrorOutputDataの橋渡しのみ、エラー処理はView層
+2. **エラー伝播**: コールバックからのエラーは呼び出し元（Interactor経由）に伝播
+3. **データ検証**: ErrorOutputDataの正当性はInteractor層で保証済み
+
+## テストファイル構成
+
+```
+tests/unit/interface-adapters/presenters/DeleteRulePresenter/presentError/
+└── normal-cases.test.ts       # コールバック呼び出し確認（配列ベース）
+```
+
+## モック戦略
+
+コンストラクタに渡すコールバック関数をvi.fn()でモック化してテストする。
+
+### モック対象
+
+| 依存関係 | モック方法 | 理由 |
+|---------|-----------|------|
+| removeRuleFromView | vi.fn() | 呼び出されないことの確認 |
+| showErrorInView | vi.fn() | 呼び出しと引数の検証 |
+
+### テストデータ
+
+DeleteRuleErrorOutputDataは実インスタンスを使用（メッセージ抽出の動作確認のため）。

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/DeleteRulePresenter/present/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/DeleteRulePresenter/present/normal-cases.test.ts
@@ -1,0 +1,49 @@
+/**
+ * DeleteRulePresenter.present - 正常系テスト（コールバック呼び出し）
+ * 1. deletedRuleIdでremoveRuleFromViewコールバックが呼び出される
+ * 2. showErrorInViewは呼び出されない（コールバック分離）
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DeleteRuleOutputData } from 'src/application-business-rules/dto/output/DeleteRuleOutputData';
+import { DeleteRulePresenter } from 'src/interface-adapters/presenters/DeleteRulePresenter';
+
+describe('DeleteRulePresenter.present - 正常系（コールバック呼び出し）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const testCases = [
+    {
+      description: 'deletedRuleId=1でremoveRuleFromViewコールバックが呼び出される',
+      input: {
+        deletedRuleId: 1,
+      },
+    },
+    {
+      description: 'deletedRuleId=999でremoveRuleFromViewコールバックが呼び出される',
+      input: {
+        deletedRuleId: 999,
+      },
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, () => {
+      const outputData = new DeleteRuleOutputData(testCase.input.deletedRuleId);
+      const mockRemoveRuleFromView = vi.fn();
+      const mockShowErrorInView = vi.fn();
+
+      const presenter = new DeleteRulePresenter(mockRemoveRuleFromView, mockShowErrorInView);
+      presenter.present(outputData);
+
+      expect(mockRemoveRuleFromView).toHaveBeenCalledTimes(1);
+      expect(mockRemoveRuleFromView).toHaveBeenCalledWith(testCase.input.deletedRuleId);
+      expect(mockShowErrorInView).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/DeleteRulePresenter/presentError/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/DeleteRulePresenter/presentError/normal-cases.test.ts
@@ -1,0 +1,66 @@
+/**
+ * DeleteRulePresenter.presentError - 正常系テスト（コールバック呼び出し）
+ * 1. エラーデータでshowErrorInViewコールバックが呼び出され、ruleIdとmessageが正しく渡される
+ * 2. removeRuleFromViewは呼び出されない（コールバック分離）
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DeleteRuleErrorOutputData } from 'src/application-business-rules/dto/output/DeleteRuleErrorOutputData';
+import { DeleteRulePresenter } from 'src/interface-adapters/presenters/DeleteRulePresenter';
+
+describe('DeleteRulePresenter.presentError - 正常系（コールバック呼び出し）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const testCases = [
+    {
+      description: 'Errorオブジェクト由来のエラーでコールバックが呼び出され、ruleIdとmessageが正しく渡される',
+      input: {
+        ruleId: 1,
+        error: new Error('削除に失敗しました'),
+      },
+      expected: {
+        ruleId: 1,
+        message: '削除に失敗しました',
+      },
+    },
+    {
+      description: '文字列由来のエラーでコールバックが呼び出され、ruleIdとmessageが正しく渡される',
+      input: {
+        ruleId: 2,
+        error: '文字列エラー',
+      },
+      expected: {
+        ruleId: 2,
+        message: '文字列エラー',
+      },
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, () => {
+      const mockRemoveRuleFromView = vi.fn();
+      const mockShowErrorInView = vi.fn();
+
+      const presenter = new DeleteRulePresenter(mockRemoveRuleFromView, mockShowErrorInView);
+      const errorData = new DeleteRuleErrorOutputData(
+        testCase.input.ruleId,
+        testCase.input.error
+      );
+
+      presenter.presentError(errorData);
+
+      expect(mockShowErrorInView).toHaveBeenCalledTimes(1);
+      expect(mockShowErrorInView).toHaveBeenCalledWith(
+        testCase.expected.ruleId,
+        testCase.expected.message
+      );
+      expect(mockRemoveRuleFromView).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Add test strategy documents and unit tests for DeleteRulePresenter:
- present(): validates removeRuleFromView callback with deletedRuleId
- presentError(): validates showErrorInView callback with ruleId and message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 設計ドキュメントを追加し、削除機能の仕様と検証方針を明確化しました。

* **Tests**
  * 削除機能のテストカバレッジを強化しました。正常系のテストを追加し、コールバック動作を検証します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->