### PR TITLE
Integrate DeleteButton into RuleTableRow component

### DIFF
--- a/docs/design/src/components/molecules/RuleTableRow/render.md
+++ b/docs/design/src/components/molecules/RuleTableRow/render.md
@@ -1,0 +1,116 @@
+# RuleTableRow コンポーネント（DeleteButton統合）テスト戦略
+
+## 目的
+
+ルール一覧の行コンポーネントにDeleteButtonを統合し、削除操作のトリガーを提供する。
+DeleteButtonのクリック時にonDeleteコールバックを呼び出し、isDeleting状態で操作を無効化する。
+
+## 前提
+
+- RuleTableRowは既存コンポーネント（onEdit、onToggle機能あり）
+- DeleteButtonは既にatoms層で実装・テスト済み
+- 本テストはDeleteButtonの統合に関するテストのみを実施
+
+## テスト分類
+
+### 1. レンダリング（DeleteButton表示）
+
+DeleteButtonが正しい位置に正しいpropsでレンダリングされることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| DeleteButton表示 | DeleteButtonコンポーネントがレンダリングされる | AC-1: ルール一覧の各行にゴミ箱アイコンが表示される |
+| isDeleting=false | DeleteButtonがdisabled=falseでレンダリングされる | 通常状態の確認 |
+| isDeleting=true | DeleteButtonがdisabled=trueでレンダリングされる | AC-8: 削除処理中は同じルールの削除ボタンが無効化される |
+
+**対応テスト**: `delete-button-rendering.test.tsx`
+
+### 2. イベント処理
+
+DeleteButtonクリック時のonDeleteコールバック呼び出しを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| クリック | onDeleteがruleIdを引数に呼ばれる | 削除フロー開始のトリガー |
+| isDeleting時 | onDeleteが呼ばれない | AC-8準拠（連続削除防止） |
+
+**対応テスト**: `delete-button-interaction.test.tsx`
+
+### 3. 既存機能との共存
+
+DeleteButton追加後も既存機能が正常に動作することを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| onEdit | 編集ボタンクリックでonEditが呼ばれる | 既存機能の回帰防止 |
+| onToggle | トグルスイッチ操作でonToggleが呼ばれる | 既存機能の回帰防止 |
+
+**対応テスト**: `existing-features.test.tsx`
+
+## 網羅性チェック
+
+- [x] DeleteButtonのレンダリング確認
+- [x] isDeleting=false/trueのdisabled状態
+- [x] onDelete呼び出し（ruleId引数確認）
+- [x] isDeleting時のonDelete抑制
+- [x] 既存機能（onEdit、onToggle）の動作確認
+- [ ] DeleteButtonの位置確認 → 対象外（視覚的確認はStorybookで実施）
+- [ ] DeleteButtonのスタイル確認 → 対象外（atoms層で検証済み）
+
+## テストファイル構成
+
+```
+tests/unit/components/molecules/RuleTableRow/
+├── test-helpers.tsx               # 共通テストヘルパー（RuleTableRowTestHelper）
+├── delete-button-rendering.test.tsx   # DeleteButtonレンダリング（3ケース）
+├── delete-button-interaction.test.tsx # DeleteButtonインタラクション（2ケース）
+└── existing-features.test.tsx         # 既存機能（2ケース）
+```
+
+## モック戦略
+
+### モック対象
+
+- **onDelete**: vi.fn()でモック化し、呼び出しと引数を検証
+- **onEdit**: vi.fn()でモック化し、呼び出しと引数を検証
+- **onToggle**: vi.fn()でモック化し、呼び出しと引数を検証
+
+### テスト環境
+
+- ReactDOM.createRoot()を使用した直接レンダリング
+- happy-dom環境（vitest設定済み）
+
+### テストヘルパー
+
+共通のセットアップ・クリーンアップロジックを`RuleTableRowTestHelper`クラスに集約:
+
+```typescript
+import { RuleTableRowTestHelper } from 'tests/unit/.../test-helpers';
+
+const helper = new RuleTableRowTestHelper();
+
+beforeEach(() => helper.setup());
+afterEach(() => helper.cleanup());
+
+// レンダリング
+await helper.render({
+  rule: mockRule,
+  onEdit: mockOnEdit,
+  onToggle: mockOnToggle,
+  onDelete: mockOnDelete,
+  isToggling: false,
+  isDeleting: false,
+});
+
+// 要素取得
+const deleteButton = helper.getDeleteButton();
+```
+
+### モックファイル構成
+
+```
+tests/unit/components/molecules/RuleTableRow/
+├── test-helpers.tsx               # RuleTableRowTestHelper + モックRewriteRule生成
+└── mocks/
+    └── createMockRewriteRule.ts   # モックRewriteRuleファクトリ
+```

--- a/host-frontend-root/frontend-src-root/src/components/atoms/Button.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/atoms/Button.tsx
@@ -8,6 +8,8 @@ interface ButtonProps {
   variant?: 'primary' | 'secondary';
   disabled?: boolean;
   type?: 'button' | 'submit' | 'reset';
+  'data-testid'?: string;
+  'aria-label'?: string;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -15,7 +17,9 @@ export const Button: React.FC<ButtonProps> = ({
   onClick,
   variant = 'primary',
   disabled = false,
-  type = 'button'
+  type = 'button',
+  'data-testid': dataTestId,
+  'aria-label': ariaLabel,
 }) => {
   return (
     <button
@@ -23,6 +27,8 @@ export const Button: React.FC<ButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       type={type}
+      data-testid={dataTestId}
+      aria-label={ariaLabel}
     >
       {children}
     </button>

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.module.css
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.module.css
@@ -10,3 +10,8 @@
   text-align: center;
   vertical-align: middle;
 }
+
+.deleteCell {
+  text-align: center;
+  vertical-align: middle;
+}

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.module.css
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.module.css
@@ -6,12 +6,7 @@
   background-color: var(--colors-bg-hover);
 }
 
-.toggleCell {
-  text-align: center;
-  vertical-align: middle;
-}
-
-.deleteCell {
+.actionCell {
   text-align: center;
   vertical-align: middle;
 }

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.stories.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.stories.tsx
@@ -12,16 +12,24 @@ const meta: Meta<typeof RuleTableRow> = {
   tags: ['autodocs'],
   argTypes: {
     onEdit: { action: 'edited' },
+    onToggle: { action: 'toggled' },
+    onDelete: { action: 'deleted' },
+  },
+  args: {
+    isToggling: false,
+    isDeleting: false,
   },
   decorators: [
     (Story) => (
       <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
         <thead>
           <tr>
-            <th style={{ width: '60px' }}>操作</th>
+            <th style={{ width: '60px' }}>有効</th>
+            <th style={{ width: '60px' }}>編集</th>
+            <th style={{ width: '60px' }}>削除</th>
             <th style={{ width: '200px' }}>URLパターン</th>
-            <th style={{ width: 'calc((100% - 260px) / 2)' }}>置換前</th>
-            <th style={{ width: 'calc((100% - 260px) / 2)' }}>置換後</th>
+            <th style={{ width: 'calc((100% - 380px) / 2)' }}>置換前</th>
+            <th style={{ width: 'calc((100% - 380px) / 2)' }}>置換後</th>
           </tr>
         </thead>
         <tbody>
@@ -123,5 +131,33 @@ export const InactiveRule: Story = {
       false,
       false
     ),
+  },
+};
+
+export const Deleting: Story = {
+  args: {
+    rule: new RewriteRule(
+      8,
+      'deleting',
+      'rule',
+      'https://example.com',
+      false,
+      true
+    ),
+    isDeleting: true,
+  },
+};
+
+export const Toggling: Story = {
+  args: {
+    rule: new RewriteRule(
+      9,
+      'toggling',
+      'rule',
+      'https://example.com',
+      false,
+      true
+    ),
+    isToggling: true,
   },
 };

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
@@ -35,7 +35,9 @@ const RuleTableRow: React.FC<RuleTableRowProps> = ({
         />
       </td>
       <td>
-        <Button onClick={() => onEdit(rule.id)}>編集</Button>
+        <Button onClick={() => onEdit(rule.id)} data-testid="edit-button">
+          編集
+        </Button>
       </td>
       <td className={styles.actionCell}>
         <DeleteButton onClick={() => onDelete(rule.id)} disabled={isDeleting} />

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
@@ -26,7 +26,7 @@ const RuleTableRow: React.FC<RuleTableRowProps> = ({
 }) => {
   return (
     <tr className={styles.ruleRow}>
-      <td className={styles.toggleCell}>
+      <td className={styles.actionCell}>
         <ToggleSwitch
           checked={rule.isActive}
           onChange={() => onToggle(rule.id)}
@@ -37,7 +37,7 @@ const RuleTableRow: React.FC<RuleTableRowProps> = ({
       <td>
         <Button onClick={() => onEdit(rule.id)}>編集</Button>
       </td>
-      <td className={styles.deleteCell}>
+      <td className={styles.actionCell}>
         <DeleteButton onClick={() => onDelete(rule.id)} disabled={isDeleting} />
       </td>
       <td title={rule.urlPattern || ''} className="rule-url-pattern">

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
@@ -4,16 +4,26 @@ import { Button } from 'src/components/atoms/Button';
 import { TruncatedText } from 'src/components/atoms/TruncatedText';
 import styles from 'src/components/molecules/RuleTableRow/RuleTableRow.module.css';
 import { RewriteRule } from 'src/enterprise-business-rules/entities/RewriteRule/RewriteRule';
+import { DeleteButton } from 'src/frameworks-and-drivers/ui/components/atoms/DeleteButton';
 import { ToggleSwitch } from 'src/frameworks-and-drivers/ui/components/atoms/ToggleSwitch';
 
 interface RuleTableRowProps {
   rule: RewriteRule;
   onEdit: (ruleId: string | number) => void;
   onToggle: (ruleId: number) => void;
+  onDelete: (ruleId: number) => void;
   isToggling: boolean;
+  isDeleting: boolean;
 }
 
-const RuleTableRow: React.FC<RuleTableRowProps> = ({ rule, onEdit, onToggle, isToggling }) => {
+const RuleTableRow: React.FC<RuleTableRowProps> = ({
+  rule,
+  onEdit,
+  onToggle,
+  onDelete,
+  isToggling,
+  isDeleting,
+}) => {
   return (
     <tr className={styles.ruleRow}>
       <td className={styles.toggleCell}>
@@ -26,6 +36,9 @@ const RuleTableRow: React.FC<RuleTableRowProps> = ({ rule, onEdit, onToggle, isT
       </td>
       <td>
         <Button onClick={() => onEdit(rule.id)}>編集</Button>
+      </td>
+      <td className={styles.deleteCell}>
+        <DeleteButton onClick={() => onDelete(rule.id)} disabled={isDeleting} />
       </td>
       <td title={rule.urlPattern || ''} className="rule-url-pattern">
         <TruncatedText text={rule.urlPattern} maxLength={30} />

--- a/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/molecules/RuleTableRow/RuleTableRow.tsx
@@ -35,7 +35,11 @@ const RuleTableRow: React.FC<RuleTableRowProps> = ({
         />
       </td>
       <td>
-        <Button onClick={() => onEdit(rule.id)} data-testid="edit-button">
+        <Button
+          onClick={() => onEdit(rule.id)}
+          data-testid="edit-button"
+          aria-label={`ルール ${rule.id} を編集`}
+        >
           編集
         </Button>
       </td>

--- a/host-frontend-root/frontend-src-root/src/components/organisms/RulesTable/RulesTable.stories.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/organisms/RulesTable/RulesTable.stories.tsx
@@ -12,6 +12,12 @@ const meta: Meta<typeof RulesTable> = {
   tags: ['autodocs'],
   argTypes: {
     onEdit: { action: 'edited' },
+    onToggle: { action: 'toggled' },
+    onDelete: { action: 'deleted' },
+  },
+  args: {
+    togglingIds: new Set<number>(),
+    deletingIds: new Set<number>(),
   },
 };
 
@@ -119,5 +125,19 @@ export const InactiveRules: Story = {
       new RewriteRule(2, 'inactive', 'replacement2', 'https://example.com', false, false),
       new RewriteRule(3, 'active2', 'replacement3', 'https://example.com', false, true),
     ],
+  },
+};
+
+export const WithDeletingRule: Story = {
+  args: {
+    rules: sampleRules,
+    deletingIds: new Set<number>([2]),
+  },
+};
+
+export const WithTogglingRule: Story = {
+  args: {
+    rules: sampleRules,
+    togglingIds: new Set<number>([1]),
   },
 };

--- a/host-frontend-root/frontend-src-root/src/components/organisms/RulesTable/RulesTable.tsx
+++ b/host-frontend-root/frontend-src-root/src/components/organisms/RulesTable/RulesTable.tsx
@@ -8,17 +8,27 @@ interface RulesTableProps {
   rules: RewriteRule[];
   onEdit: (ruleId: string | number) => void;
   onToggle: (ruleId: number) => void;
+  onDelete: (ruleId: number) => void;
   togglingIds: Set<number>;
+  deletingIds: Set<number>;
 }
 
-const RulesTable: React.FC<RulesTableProps> = ({ rules, onEdit, onToggle, togglingIds }) => {
+const RulesTable: React.FC<RulesTableProps> = ({
+  rules,
+  onEdit,
+  onToggle,
+  onDelete,
+  togglingIds,
+  deletingIds,
+}) => {
   return (
     <div className={styles.rulesTableContainer} data-testid="rules-table-container">
       <table className={styles.rulesTable} data-testid="rules-table">
         <thead>
           <tr>
             <th>有効</th>
-            <th>操作</th>
+            <th>編集</th>
+            <th>削除</th>
             <th>URLパターン</th>
             <th>置換前</th>
             <th>置換後</th>
@@ -31,7 +41,9 @@ const RulesTable: React.FC<RulesTableProps> = ({ rules, onEdit, onToggle, toggli
               rule={rule}
               onEdit={onEdit}
               onToggle={onToggle}
+              onDelete={onDelete}
               isToggling={togglingIds.has(rule.id)}
+              isDeleting={deletingIds.has(rule.id)}
             />
           ))}
         </tbody>

--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/pages/rules/RulesApp.tsx
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/pages/rules/RulesApp.tsx
@@ -19,6 +19,7 @@ function RulesApp() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
+  const [deletingIds] = useState<Set<number>>(new Set());
   const [toggleError, setToggleError] = useState<{ ruleId: number; message: string } | null>(null);
 
   const toggleController = useMemo(() => {
@@ -111,6 +112,10 @@ function RulesApp() {
     });
   };
 
+  const handleDelete = (_ruleId: number) => {
+    // TODO: P3-2で削除処理を実装
+  };
+
   return (
     <div className="container">
       <h1>保存されたルール一覧</h1>
@@ -124,7 +129,14 @@ function RulesApp() {
       {rules.length === 0 ? (
         <EmptyStateMessage />
       ) : (
-        <RulesTable rules={rules} onEdit={handleEdit} onToggle={handleToggle} togglingIds={togglingIds} />
+        <RulesTable
+          rules={rules}
+          onEdit={handleEdit}
+          onToggle={handleToggle}
+          onDelete={handleDelete}
+          togglingIds={togglingIds}
+          deletingIds={deletingIds}
+        />
       )}
 
       <div className="footer">

--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/pages/rules/RulesApp.tsx
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/ui/pages/rules/RulesApp.tsx
@@ -114,6 +114,7 @@ function RulesApp() {
 
   const handleDelete = (_ruleId: number) => {
     // TODO: P3-2で削除処理を実装
+    void _ruleId;
   };
 
   return (

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/delete-button-interaction.test.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/delete-button-interaction.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * RuleTableRow - DeleteButton インタラクションテスト
+ * テスト戦略書: docs/design/src/components/molecules/RuleTableRow/render.md
+ *
+ * テストケース:
+ * 1. クリックでonDeleteがruleIdを引数に呼ばれる
+ * 2. isDeleting時はonDeleteが呼ばれない
+ */
+import { createMockRewriteRule } from 'tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule';
+import { RuleTableRowTestHelper } from 'tests/unit/components/molecules/RuleTableRow/test-helpers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('RuleTableRow - DeleteButton インタラクション', () => {
+  const helper = new RuleTableRowTestHelper();
+  const mockOnEdit = vi.fn();
+  const mockOnToggle = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    helper.setup();
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('クリックでonDeleteがruleIdを引数に呼ばれる', async () => {
+    // Arrange
+    const ruleId = 42;
+    const rule = createMockRewriteRule({ id: ruleId });
+    await helper.render({
+      rule,
+      onEdit: mockOnEdit,
+      onToggle: mockOnToggle,
+      onDelete: mockOnDelete,
+      isToggling: false,
+      isDeleting: false,
+    });
+
+    // Act
+    const deleteButton = helper.getDeleteButton();
+    deleteButton?.click();
+
+    // Assert
+    expect(mockOnDelete).toHaveBeenCalledTimes(1);
+    expect(mockOnDelete).toHaveBeenCalledWith(ruleId);
+  });
+
+  it('isDeleting時はonDeleteが呼ばれない', async () => {
+    // Arrange
+    const rule = createMockRewriteRule();
+    await helper.render({
+      rule,
+      onEdit: mockOnEdit,
+      onToggle: mockOnToggle,
+      onDelete: mockOnDelete,
+      isToggling: false,
+      isDeleting: true,
+    });
+
+    // Act
+    const deleteButton = helper.getDeleteButton();
+    deleteButton?.click();
+
+    // Assert
+    expect(mockOnDelete).not.toHaveBeenCalled();
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/delete-button-rendering.test.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/delete-button-rendering.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * RuleTableRow - DeleteButton レンダリングテスト
+ * テスト戦略書: docs/design/src/components/molecules/RuleTableRow/render.md
+ *
+ * テストケース:
+ * 1. DeleteButtonコンポーネントがレンダリングされる
+ * 2. isDeleting=falseの場合、DeleteButtonがdisabled=falseでレンダリングされる
+ * 3. isDeleting=trueの場合、DeleteButtonがdisabled=trueでレンダリングされる
+ */
+import { createMockRewriteRule } from 'tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule';
+import { RuleTableRowTestHelper } from 'tests/unit/components/molecules/RuleTableRow/test-helpers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('RuleTableRow - DeleteButton レンダリング', () => {
+  const helper = new RuleTableRowTestHelper();
+  const mockOnEdit = vi.fn();
+  const mockOnToggle = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    helper.setup();
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('DeleteButtonコンポーネントがレンダリングされる', async () => {
+    // Arrange
+    const rule = createMockRewriteRule();
+
+    // Act
+    await helper.render({
+      rule,
+      onEdit: mockOnEdit,
+      onToggle: mockOnToggle,
+      onDelete: mockOnDelete,
+      isToggling: false,
+      isDeleting: false,
+    });
+
+    // Assert
+    const deleteButton = helper.getDeleteButton();
+    expect(deleteButton).not.toBeNull();
+    expect(deleteButton?.getAttribute('aria-label')).toBe('ルールを削除');
+  });
+
+  const disabledTestCases = [
+    {
+      description:
+        'isDeleting=falseの場合、DeleteButtonがdisabled=falseでレンダリングされる',
+      isDeleting: false,
+      expectedDisabled: false,
+    },
+    {
+      description:
+        'isDeleting=trueの場合、DeleteButtonがdisabled=trueでレンダリングされる',
+      isDeleting: true,
+      expectedDisabled: true,
+    },
+  ];
+
+  disabledTestCases.forEach((testCase) => {
+    it(testCase.description, async () => {
+      // Arrange
+      const rule = createMockRewriteRule();
+
+      // Act
+      await helper.render({
+        rule,
+        onEdit: mockOnEdit,
+        onToggle: mockOnToggle,
+        onDelete: mockOnDelete,
+        isToggling: false,
+        isDeleting: testCase.isDeleting,
+      });
+
+      // Assert
+      const deleteButton = helper.getDeleteButton();
+      expect(deleteButton).not.toBeNull();
+      expect(deleteButton?.disabled).toBe(testCase.expectedDisabled);
+    });
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/existing-features.test.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/existing-features.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * RuleTableRow - 既存機能テスト
+ * テスト戦略書: docs/design/src/components/molecules/RuleTableRow/render.md
+ *
+ * DeleteButton追加後も既存機能が正常に動作することを確認
+ * テストケース:
+ * 1. 編集ボタンクリックでonEditが呼ばれる
+ * 2. トグルスイッチ操作でonToggleが呼ばれる
+ */
+import { act } from 'react';
+import { createMockRewriteRule } from 'tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule';
+import {
+  flushPromises,
+  RuleTableRowTestHelper,
+} from 'tests/unit/components/molecules/RuleTableRow/test-helpers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('RuleTableRow - 既存機能', () => {
+  const helper = new RuleTableRowTestHelper();
+  const mockOnEdit = vi.fn();
+  const mockOnToggle = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    helper.setup();
+  });
+
+  afterEach(() => {
+    helper.cleanup();
+  });
+
+  it('編集ボタンクリックでonEditが呼ばれる', async () => {
+    // Arrange
+    const ruleId = 123;
+    const rule = createMockRewriteRule({ id: ruleId });
+    await helper.render({
+      rule,
+      onEdit: mockOnEdit,
+      onToggle: mockOnToggle,
+      onDelete: mockOnDelete,
+      isToggling: false,
+      isDeleting: false,
+    });
+
+    // Act
+    const editButton = helper.getEditButton();
+    editButton?.click();
+
+    // Assert
+    expect(mockOnEdit).toHaveBeenCalledTimes(1);
+    expect(mockOnEdit).toHaveBeenCalledWith(ruleId);
+  });
+
+  it('トグルスイッチ操作でonToggleが呼ばれる', async () => {
+    // Arrange
+    const ruleId = 456;
+    const rule = createMockRewriteRule({ id: ruleId });
+    await helper.render({
+      rule,
+      onEdit: mockOnEdit,
+      onToggle: mockOnToggle,
+      onDelete: mockOnDelete,
+      isToggling: false,
+      isDeleting: false,
+    });
+
+    // Act
+    const toggleSwitch = helper.getToggleSwitch();
+    await act(async () => {
+      toggleSwitch?.click();
+      await flushPromises();
+    });
+
+    // Assert
+    expect(mockOnToggle).toHaveBeenCalledTimes(1);
+    expect(mockOnToggle).toHaveBeenCalledWith(ruleId);
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/existing-features.test.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/existing-features.test.tsx
@@ -7,9 +7,9 @@
  * 1. 編集ボタンクリックでonEditが呼ばれる
  * 2. トグルスイッチ操作でonToggleが呼ばれる
  */
-import { act } from 'react';
 import { createMockRewriteRule } from 'tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule';
 import {
+  act,
   flushPromises,
   RuleTableRowTestHelper,
 } from 'tests/unit/components/molecules/RuleTableRow/test-helpers';

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/mocks/createMockRewriteRule.ts
@@ -1,0 +1,31 @@
+/**
+ * RuleTableRow テスト用モックRewriteRuleファクトリ
+ */
+import { RewriteRule } from 'src/enterprise-business-rules/entities/RewriteRule/RewriteRule';
+
+interface CreateMockRewriteRuleOptions {
+  id?: number;
+  oldString?: string;
+  newString?: string;
+  urlPattern?: string;
+  isRegex?: boolean;
+  isActive?: boolean;
+}
+
+/**
+ * テスト用のモックRewriteRuleを作成する
+ * @param options オプションでプロパティを上書き可能
+ * @returns RewriteRuleインスタンス
+ */
+export function createMockRewriteRule(
+  options: CreateMockRewriteRuleOptions = {}
+): RewriteRule {
+  return new RewriteRule(
+    options.id ?? 1,
+    options.oldString ?? 'old-string',
+    options.newString ?? 'new-string',
+    options.urlPattern ?? 'https://example.com',
+    options.isRegex ?? false,
+    options.isActive ?? true
+  );
+}

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
@@ -93,16 +93,13 @@ export class RuleTableRowTestHelper {
 
   /**
    * 編集ボタンを取得
+   * data-testidで識別
    */
   getEditButton(): HTMLButtonElement | null {
     this.ensureSetup();
-    const buttons = Array.from(this.container!.querySelectorAll('button'));
-    for (const button of buttons) {
-      if (button.textContent === '編集') {
-        return button;
-      }
-    }
-    return null;
+    return this.container!.querySelector(
+      'button[data-testid="edit-button"]'
+    ) as HTMLButtonElement | null;
   }
 
   /**

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
@@ -96,10 +96,10 @@ export class RuleTableRowTestHelper {
    */
   getEditButton(): HTMLButtonElement | null {
     this.ensureSetup();
-    const buttons = this.container!.querySelectorAll('button');
+    const buttons = Array.from(this.container!.querySelectorAll('button'));
     for (const button of buttons) {
       if (button.textContent === '編集') {
-        return button as HTMLButtonElement;
+        return button;
       }
     }
     return null;

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
@@ -1,0 +1,125 @@
+/**
+ * RuleTableRow コンポーネント テストヘルパー
+ * 複数のテストファイル間で共通のセットアップ・ヘルパー関数を提供
+ */
+import React, { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import { flushPromises } from 'tests/unit/frameworks-and-drivers/ui/test-utils';
+import { vi } from 'vitest';
+
+import RuleTableRow from 'src/components/molecules/RuleTableRow/RuleTableRow';
+
+type RuleTableRowProps = React.ComponentProps<typeof RuleTableRow>;
+
+// 後方互換性のため再エクスポート
+export { flushPromises };
+
+/**
+ * テスト用コンテナとReactルートを管理するクラス
+ * 注意: render()などのメソッドを呼ぶ前に必ずsetup()を呼び出すこと
+ */
+export class RuleTableRowTestHelper {
+  private container: HTMLDivElement | null = null;
+  private root: ReactDOM.Root | null = null;
+
+  /**
+   * setup()が呼ばれているか確認し、未呼び出しの場合はエラーをスロー
+   */
+  private ensureSetup(): void {
+    if (!this.container || !this.root) {
+      throw new Error(
+        '他のメソッドを使用する前に RuleTableRowTestHelper.setup() を呼び出す必要があります。beforeEach() 内で helper.setup() を呼び出してください。'
+      );
+    }
+  }
+
+  /**
+   * テスト前のセットアップ
+   * beforeEach 内で必ず呼び出すこと
+   */
+  setup(): void {
+    vi.clearAllMocks();
+    this.container = document.createElement('div');
+    document.body.appendChild(this.container);
+    this.root = ReactDOM.createRoot(this.container);
+  }
+
+  /**
+   * テスト後のクリーンアップ
+   * afterEach 内で呼び出す
+   * setup()が呼ばれていない場合は何もせず早期リターン
+   */
+  cleanup(): void {
+    if (!this.container || !this.root) {
+      return;
+    }
+    this.root.unmount();
+    this.container.remove();
+    this.container = null;
+    this.root = null;
+    vi.resetAllMocks();
+  }
+
+  /**
+   * コンポーネントをレンダリング
+   * act()でラップしてReact 18の非同期レンダリングを適切に処理
+   * RuleTableRowはtrの子要素なので、tableでラップしてレンダリング
+   * @param props RuleTableRowProps
+   */
+  async render(props: RuleTableRowProps): Promise<void> {
+    this.ensureSetup();
+    await act(async () => {
+      this.root!.render(
+        <table>
+          <tbody>
+            <RuleTableRow {...props} />
+          </tbody>
+        </table>
+      );
+      await flushPromises();
+    });
+  }
+
+  /**
+   * DeleteButtonのボタン要素を取得
+   * aria-labelで識別
+   */
+  getDeleteButton(): HTMLButtonElement | null {
+    this.ensureSetup();
+    return this.container!.querySelector(
+      'button[aria-label="ルールを削除"]'
+    ) as HTMLButtonElement | null;
+  }
+
+  /**
+   * 編集ボタンを取得
+   */
+  getEditButton(): HTMLButtonElement | null {
+    this.ensureSetup();
+    const buttons = this.container!.querySelectorAll('button');
+    for (const button of buttons) {
+      if (button.textContent === '編集') {
+        return button as HTMLButtonElement;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * トグルスイッチを取得
+   */
+  getToggleSwitch(): HTMLInputElement | null {
+    this.ensureSetup();
+    return this.container!.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement | null;
+  }
+
+  /**
+   * コンテナを取得
+   */
+  getContainer(): HTMLDivElement {
+    this.ensureSetup();
+    return this.container!;
+  }
+}

--- a/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
+++ b/host-frontend-root/frontend-src-root/tests/unit/components/molecules/RuleTableRow/test-helpers.tsx
@@ -11,7 +11,8 @@ import RuleTableRow from 'src/components/molecules/RuleTableRow/RuleTableRow';
 
 type RuleTableRowProps = React.ComponentProps<typeof RuleTableRow>;
 
-// 後方互換性のため再エクスポート
+// テストファイルで使用するユーティリティを再エクスポート
+export { act } from 'react';
 export { flushPromises };
 
 /**


### PR DESCRIPTION
## Summary
Integrates the DeleteButton component into the RuleTableRow molecule to enable rule deletion functionality. This change adds delete button rendering, event handling, and comprehensive unit tests while maintaining backward compatibility with existing edit and toggle features.

## Key Changes

### Component Updates
- **RuleTableRow.tsx**: Added `onDelete` callback and `isDeleting` state prop; renders DeleteButton in new table cell with disabled state management
-  **RuleTableRow.module.css**: Consolidated .toggleCell into .actionCell for both toggle and delete cells
- **RulesTable.tsx**: Updated to accept and pass through `onDelete` callback and `deletingIds` Set to RuleTableRow instances
- **RulesApp.tsx**: Added `deletingIds` state and placeholder `handleDelete` function (implementation deferred to P3-2)

### Storybook Stories
- **RuleTableRow.stories.tsx**: Added `onToggle` and `onDelete` action handlers; added `Deleting` and `Toggling` story variants; updated table header labels for clarity
- **RulesTable.stories.tsx**: Added `WithDeletingRule` and `WithTogglingRule` story variants to demonstrate state management

### Test Infrastructure
- **test-helpers.tsx**: Created `RuleTableRowTestHelper` class for consistent test setup/teardown and element queries
- **createMockRewriteRule.ts**: Factory function for generating test mock RewriteRule instances with customizable properties
- **delete-button-rendering.test.tsx**: 3 test cases covering DeleteButton presence and disabled state (isDeleting=false/true)
- **delete-button-interaction.test.tsx**: 2 test cases verifying onDelete callback invocation and suppression during deletion
- **existing-features.test.tsx**: 2 regression tests ensuring edit and toggle functionality remain unaffected

### Documentation
- **render.md**: Comprehensive test strategy document outlining test classification, coverage matrix, mock strategy, and file structure

## Implementation Details

- DeleteButton is disabled when `isDeleting={true}` to prevent duplicate deletion requests (AC-8 compliance)
- onDelete receives the rule's numeric ID as argument for deletion processing
- Test helper enforces `setup()` call before other methods to catch initialization errors early
- All tests use `act()` and `flushPromises()` for proper React 18 async handling
- Deletion handler is stubbed with TODO comment pending P3-2 implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ルール表の各行に削除ボタンを追加しました
  * 操作列を「編集」と「削除」の2列に分割しUIを整理しました
  * 削除中のルールは削除ボタンが無効化されます
  * 削除ボタンにアクセシビリティラベルを付与しました

* **ドキュメント**
  * 削除ボタン統合のテスト方針とケースを追加しました（レンダリング・操作・既存機能との共存）

* **テスト**
  * 削除ボタンのレンダリングと操作に関する単体テストを追加しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->