### PR TITLE
Add DeleteRuleController and Factory test strategies and unit tests

### DIFF
--- a/docs/design/src/interface-adapters/controllers/DeleteRuleController/deleteRule.md
+++ b/docs/design/src/interface-adapters/controllers/DeleteRuleController/deleteRule.md
@@ -54,7 +54,7 @@ tests/unit/interface-adapters/controllers/DeleteRuleController/deleteRule/
 
 UseCaseをモック化し、Controllerの責務（入力変換とUseCase呼び出し）のみをテストする。
 
-> **重要**: モック作成は [basic-rule.md](../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
+> **重要**: モック作成は [basic-rule.md](../../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
 
 ### 既存モック確認チェック（必須）
 

--- a/docs/design/src/interface-adapters/controllers/DeleteRuleController/deleteRule.md
+++ b/docs/design/src/interface-adapters/controllers/DeleteRuleController/deleteRule.md
@@ -1,0 +1,79 @@
+# DeleteRuleController.deleteRule() テスト戦略
+
+## 目的
+
+ユーザーからのruleIdを受け取り、DeleteRuleInputDataを生成してUseCaseを呼び出す。
+Controllerの責務は入力変換とUseCase呼び出しのみで、ビジネスロジックは含まない。
+
+## テスト分類
+
+### 1. 正常系（UseCase呼び出し）
+
+UseCaseのexecuteメソッドが正しく呼び出されることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| 基本パターン | ruleId=1でUseCaseが呼び出される | 最小限の正常系確認 |
+| 大きなID | ruleId=999999でUseCaseが呼び出される | 境界値（大きな値）の確認 |
+
+**対応テスト**: `normal-cases.test.ts`
+
+### 2. InputData生成
+
+UseCaseに渡されるInputDataが正しく生成されていることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| ruleId設定 | InputData.ruleIdが引数と一致 | 入力変換の正確性 |
+
+**対応テスト**: `normal-cases.test.ts`（上記と同一テスト内で検証）
+
+## 網羅性チェック
+
+- [x] UseCaseのexecuteが呼び出されること
+- [x] InputDataのruleIdが正しく設定されること
+- [ ] 異常系（UseCase側のエラー） → 不要（Controllerはエラーをキャッチせず呼び出し元に伝播）
+- [ ] ruleIdのバリデーション → 不要（責務外、Interactor層で検証）
+
+### 異常系テストが不要な理由
+
+ControllerはUseCase呼び出しのみを担当し、エラーハンドリングの責務を持たない：
+
+1. **責務の分離**: Controllerは入力変換のみ、ビジネスロジックエラーはInteractor層
+2. **エラー伝播**: UseCaseからのエラーは呼び出し元（View層）に伝播してUIで処理
+3. **バリデーション**: ruleIdの存在確認はInteractor層でRepository経由で行う
+
+## テストファイル構成
+
+```
+tests/unit/interface-adapters/controllers/DeleteRuleController/deleteRule/
+└── normal-cases.test.ts       # UseCase呼び出し確認（配列ベース、2ケース）
+```
+
+## モック戦略
+
+UseCaseをモック化し、Controllerの責務（入力変換とUseCase呼び出し）のみをテストする。
+
+> **重要**: モック作成は [basic-rule.md](../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
+
+### 既存モック確認チェック（必須）
+
+- [x] `grep -r "createMockDeleteRuleUseCase" tests/` で検索 → 新規作成（該当なし）
+
+### モック対象
+
+| 依存関係 | モック理由 | 既存モック |
+|---------|-----------|-----------|
+| IDeleteRuleUseCase | UseCase呼び出しの検証 | 新規作成 |
+
+### モックファイル構成
+
+```
+tests/unit/interface-adapters/controllers/DeleteRuleController/
+└── mocks/
+    └── createMockDeleteRuleUseCase.ts    # IDeleteRuleUseCaseモックファクトリ
+```
+
+### テストデータ
+
+DeleteRuleInputDataは実インスタンスを使用（Controllerが生成するため、引数の検証に使用）。

--- a/docs/design/src/interface-adapters/factories/DeleteRuleControllerFactory/create.md
+++ b/docs/design/src/interface-adapters/factories/DeleteRuleControllerFactory/create.md
@@ -1,0 +1,82 @@
+# DeleteRuleControllerFactory.create() テスト戦略
+
+## 目的
+
+Reactコールバック（onSuccess, onError）を受け取り、Presenter/Interactor/Controllerを生成して返す。
+Factoryの責務は「DIの世界」と「Reactの世界」の境界を橋渡しすること（ADR-005参照）。
+
+## テスト分類
+
+### 1. 正常系（Controllerの生成と統合動作）
+
+create()がIDeleteRuleControllerを返し、削除処理が正しく連携することを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| 基本パターン | create()がIDeleteRuleControllerを返す | Factoryの基本責務 |
+| 成功時コールバック | 削除成功時にonSuccessコールバックが呼ばれる | Presenter→View連携の確認 |
+| エラー時コールバック | 削除失敗時にonErrorコールバックが呼ばれる | エラー通知連携の確認 |
+
+**対応テスト**: `normal-cases.test.ts`
+
+### 2. コールバック引数の検証
+
+コールバックに正しい引数が渡されることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| 成功時引数 | onSuccessにdeletedRuleIdが渡される | Presenterの出力仕様 |
+| エラー時引数 | onErrorにruleIdとmessageが渡される | エラー通知仕様 |
+
+**対応テスト**: `normal-cases.test.ts`（同一テスト内で検証）
+
+## 網羅性チェック
+
+- [x] create()がIDeleteRuleControllerを返すこと
+- [x] 成功時にonSuccessコールバックが呼ばれること
+- [x] 成功時コールバックにdeletedRuleIdが渡されること
+- [x] エラー時にonErrorコールバックが呼ばれること
+- [x] エラー時コールバックにruleIdとmessageが渡されること
+- [ ] Factoryの内部実装（Presenter/Interactor生成順序）→ 不要（実装詳細、振る舞いで検証）
+
+### 統合テスト的アプローチの理由
+
+Factoryは複数クラスを組み立てる責務を持つため、生成されたControllerの動作を通じて検証する。
+個々のクラス（Presenter/Interactor）の詳細な動作は各クラスの単体テストでカバー済み。
+
+## テストファイル構成
+
+```
+tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/
+└── normal-cases.test.ts       # 生成と統合動作確認（配列ベース）
+```
+
+## モック戦略
+
+RepositoryとGatewayをモック化し、Factoryの責務（クラス生成と連携）をテストする。
+
+> **重要**: モック作成は [basic-rule.md](../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
+
+### 既存モック確認チェック（必須）
+
+- [x] `grep -r "createMockRewriteRuleRepository" tests/` で検索 → 既存モック使用 (`tests/unit/application/ports/IRewriteRuleRepository/mocks/createMockRewriteRuleRepository.ts`)
+- [x] `grep -r "createMockTabsGateway" tests/` で検索 → 既存モック使用 (`tests/frameworks-and-drivers/browser/ChromeTabsGateway/createMockTabsGateway.ts`)
+
+### モック対象
+
+| 依存関係 | モック理由 | 既存モック |
+|---------|-----------|-----------|
+| IRewriteRuleRepository | DB操作の回避、成功/失敗シナリオの制御 | `tests/unit/application/ports/IRewriteRuleRepository/mocks/createMockRewriteRuleRepository.ts` |
+| ITabsGateway | Chrome API依存の回避 | `tests/frameworks-and-drivers/browser/ChromeTabsGateway/createMockTabsGateway.ts` |
+
+### コールバックのモック
+
+| 対象 | モック方法 | 理由 |
+|-----|-----------|------|
+| onSuccess | vi.fn() | 呼び出しと引数の検証 |
+| onError | vi.fn() | 呼び出しと引数の検証 |
+
+### テストデータ
+
+- ruleId: 任意の正の整数を使用
+- RewriteRule: モックRepositoryから返却するダミーエンティティ

--- a/docs/design/src/interface-adapters/factories/DeleteRuleControllerFactory/create.md
+++ b/docs/design/src/interface-adapters/factories/DeleteRuleControllerFactory/create.md
@@ -55,7 +55,7 @@ tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/
 
 RepositoryとGatewayをモック化し、Factoryの責務（クラス生成と連携）をテストする。
 
-> **重要**: モック作成は [basic-rule.md](../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
+> **重要**: モック作成は [basic-rule.md](../../../../../../coding-standards/tests/unit/common-rule/basic-rule.md) の「モック作成の分離ルール」に従うこと。
 
 ### 既存モック確認チェック（必須）
 

--- a/docs/user-stories/user-story-003/README.md
+++ b/docs/user-stories/user-story-003/README.md
@@ -166,8 +166,8 @@ Phase 2以降では、以下の原則に従って実装順序を決定する:
 
 #### Controller/Presenter層
 
-- [ ] DeleteRuleController の実装、テスト戦略書・単体テスト
-- [ ] DeleteRuleControllerFactory の実装、テスト戦略書・単体テスト
+- [x] DeleteRuleController の実装、テスト戦略書・単体テスト
+- [x] DeleteRuleControllerFactory の実装、テスト戦略書・単体テスト
 - [x] DeleteRulePresenter の実装、テスト戦略書・単体テスト（成功時View更新、失敗時エラー通知）
 
 #### UIコンポーネント層

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/DeleteRuleController/deleteRule/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/DeleteRuleController/deleteRule/normal-cases.test.ts
@@ -1,0 +1,47 @@
+/**
+ * DeleteRuleController.deleteRule - 正常系テスト
+ * 1. ruleId=1 でUseCaseが呼び出される
+ * 2. 大きなruleId でUseCaseが呼び出される
+ */
+import { createMockDeleteRuleUseCase } from 'tests/unit/interface-adapters/controllers/DeleteRuleController/mocks/createMockDeleteRuleUseCase';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DeleteRuleInputData } from 'src/application-business-rules/dto/input/DeleteRuleInputData';
+import { IDeleteRuleUseCase } from 'src/application-business-rules/ports/input/IDeleteRuleUseCase';
+import { DeleteRuleController } from 'src/interface-adapters/controllers/DeleteRuleController';
+
+describe('DeleteRuleController.deleteRule - 正常系', () => {
+  let mockUseCase: IDeleteRuleUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCase = createMockDeleteRuleUseCase();
+  });
+
+  const testCases = [
+    {
+      description: 'ruleId=1 でUseCaseが呼び出される',
+      input: { ruleId: 1 },
+    },
+    {
+      description: '大きなruleId でUseCaseが呼び出される',
+      input: { ruleId: 999999 },
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, async () => {
+      const controller = new DeleteRuleController(mockUseCase);
+
+      await controller.deleteRule(testCase.input.ruleId);
+
+      expect(mockUseCase.execute).toHaveBeenCalledTimes(1);
+      expect(mockUseCase.execute).toHaveBeenCalledWith(
+        expect.any(DeleteRuleInputData)
+      );
+      const calledInputData = (mockUseCase.execute as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0] as DeleteRuleInputData;
+      expect(calledInputData.ruleId).toBe(testCase.input.ruleId);
+    });
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/DeleteRuleController/mocks/createMockDeleteRuleUseCase.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/DeleteRuleController/mocks/createMockDeleteRuleUseCase.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+import { IDeleteRuleUseCase } from 'src/application-business-rules/ports/input/IDeleteRuleUseCase';
+
+/**
+ * IDeleteRuleUseCaseのモックオブジェクトを生成する
+ * @returns IDeleteRuleUseCase型のモックオブジェクト
+ */
+export const createMockDeleteRuleUseCase = (): IDeleteRuleUseCase => {
+  return {
+    execute: vi.fn().mockResolvedValue(undefined),
+  };
+};

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts
@@ -1,0 +1,77 @@
+/**
+ * DeleteRuleControllerFactory.create - 正常系テスト
+ * 1. create()がIDeleteRuleControllerを返す
+ * 2. 削除成功時にonSuccessコールバックが呼ばれる
+ * 3. 削除失敗時にonErrorコールバックが呼ばれる
+ */
+import { createMockTabsGateway } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/createMockTabsGateway';
+import { createMockRewriteRuleRepository as createMockRepository } from 'tests/unit/application/ports/IRewriteRuleRepository/mocks/createMockRewriteRuleRepository';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IRewriteRuleRepository } from 'src/application-business-rules/ports/gateway/IRewriteRuleRepository';
+import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { RewriteRule } from 'src/enterprise-business-rules/entities/RewriteRule/RewriteRule';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+import {
+  DeleteErrorCallback,
+  DeleteSuccessCallback,
+} from 'src/interface-adapters/factories/IDeleteRuleControllerFactory';
+
+describe('DeleteRuleControllerFactory.create - 正常系', () => {
+  let mockRepository: IRewriteRuleRepository;
+  let mockTabsGateway: ITabsGateway;
+  let onSuccess: DeleteSuccessCallback;
+  let onError: DeleteErrorCallback;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRepository = createMockRepository();
+    mockTabsGateway = createMockTabsGateway();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('create()がIDeleteRuleControllerを返す', () => {
+    const factory = new DeleteRuleControllerFactory(mockRepository, mockTabsGateway);
+
+    const controller = factory.create(onSuccess, onError);
+
+    expect(controller).toBeDefined();
+    expect(typeof controller.deleteRule).toBe('function');
+  });
+
+  it('削除成功時にonSuccessコールバックが呼ばれる', async () => {
+    const ruleId = 1;
+    const rule = new RewriteRule(ruleId, 'oldString', 'newString', 'https://example.com', false, true);
+    (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
+    (mockRepository.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const factory = new DeleteRuleControllerFactory(mockRepository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    await controller.deleteRule(ruleId);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(ruleId);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('削除失敗時にonErrorコールバックが呼ばれる', async () => {
+    const ruleId = 999;
+    const errorMessage = 'Rule not found';
+    (mockRepository.getById as ReturnType<typeof vi.fn>).mockRejectedValue(new Error(errorMessage));
+
+    const factory = new DeleteRuleControllerFactory(mockRepository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    await controller.deleteRule(ruleId);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(ruleId, errorMessage);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive test strategies and unit tests for the DeleteRuleController and DeleteRuleControllerFactory, completing the Controller/Presenter layer implementation for the rule deletion feature (User Story 003).

## Key Changes

### Documentation
- **DeleteRuleController test strategy** (`docs/design/src/interface-adapters/controllers/DeleteRuleController/deleteRule.md`)
  - Defines test classification: normal cases (UseCase invocation with various ruleId values)
  - Explains why abnormal cases are not needed (error handling is caller's responsibility)
  - Documents mock strategy and test file structure

- **DeleteRuleControllerFactory test strategy** (`docs/design/src/interface-adapters/factories/DeleteRuleControllerFactory/create.md`)
  - Defines test classification: Controller generation, success callback invocation, error callback invocation
  - Explains integration testing approach (verifying behavior through generated Controller)
  - Documents mock strategy using existing Repository and Gateway mocks

### Implementation
- **DeleteRuleController unit tests** (`tests/unit/interface-adapters/controllers/DeleteRuleController/deleteRule/normal-cases.test.ts`)
  - 2 test cases: basic ruleId=1 and boundary value ruleId=999999
  - Verifies UseCase.execute() is called with correct InputData
  - Uses array-based test case structure for maintainability

- **DeleteRuleController mock factory** (`tests/unit/interface-adapters/controllers/DeleteRuleController/mocks/createMockDeleteRuleUseCase.ts`)
  - Creates IDeleteRuleUseCase mock with resolved execute method
  - Follows separation of concerns rule from coding standards

- **DeleteRuleControllerFactory unit tests** (`tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts`)
  - 3 test cases: Controller creation, success callback with deletedRuleId, error callback with ruleId and message
  - Verifies end-to-end integration through generated Controller
  - Reuses existing Repository and Gateway mocks

### Status Update
- Updated User Story 003 checklist: marked DeleteRuleController and DeleteRuleControllerFactory as complete

## Notable Implementation Details

- **Separation of concerns**: Controller tests focus only on UseCase invocation; Factory tests verify integration through behavior
- **Mock reuse**: Factory tests leverage existing mocks (IRewriteRuleRepository, ITabsGateway) to avoid duplication
- **Callback verification**: Factory tests confirm correct callback invocation with proper arguments (deletedRuleId for success, ruleId+message for error)
- **No abnormal case testing**: Controller doesn't test error scenarios as error handling is the caller's responsibility per architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ルール削除機能のテスト戦略ドキュメントを追加しました。

* **Tests**
  * ルール削除の単体テストを実装しました。

* **Chores**
  * プロジェクトの実装完了状況を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->