### PR TITLE
Add DeleteRuleControllerFactory to DI container

### DIFF
--- a/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/di/container.ts
+++ b/host-frontend-root/frontend-src-root/src/frameworks-and-drivers/di/container.ts
@@ -25,6 +25,8 @@ import { ChromeTabsService } from 'src/infrastructure/browser/tabs/ChromeTabsSer
 import { ChromeWindowService } from 'src/infrastructure/browser/window/ChromeWindowService';
 import { SelectedPageTextRepository } from 'src/infrastructure/persistence/storage/SelectedPageTextRepository';
 import { GetSelectionService } from 'src/infrastructure/windows/getSelectionService';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+import { IDeleteRuleControllerFactory } from 'src/interface-adapters/factories/IDeleteRuleControllerFactory';
 import { IToggleRuleActiveControllerFactory } from 'src/interface-adapters/factories/IToggleRuleActiveControllerFactory';
 import { ToggleRuleActiveControllerFactory } from 'src/interface-adapters/factories/ToggleRuleActiveControllerFactory';
 import { RewriteRuleMapper } from 'src/interface-adapters/mappers/RewriteRuleMapper';
@@ -71,6 +73,10 @@ const toggleRuleActiveControllerFactory = new ToggleRuleActiveControllerFactory(
   rewriteRuleRepository,
   chromeTabsGateway
 );
+const deleteRuleControllerFactory = new DeleteRuleControllerFactory(
+  rewriteRuleRepository,
+  chromeTabsGateway
+);
 // NOTE: Background contextでは DexieRewriteRuleRepository を直接使用するため、
 // RewriteRuleMessagingService の getAll() は呼ばれない（Mapper 経由の getAllRules は未使用）
 const rewriteRuleMessagingService = new RewriteRuleMessagingService();
@@ -105,7 +111,10 @@ awilixContainer.register({
   toggleRuleActiveControllerFactory: asValue(toggleRuleActiveControllerFactory),
   rewriteRuleMapper: asValue(rewriteRuleMapper),
   chromeTabsGateway: asValue(chromeTabsGateway),
-  rewriteRuleMessagingService: asValue(rewriteRuleMessagingService)
+  rewriteRuleMessagingService: asValue(rewriteRuleMessagingService),
+
+  // Delete Rule feature
+  deleteRuleControllerFactory: asValue(deleteRuleControllerFactory)
 });
 
 // Type definitions for container resolution
@@ -138,6 +147,9 @@ interface ContainerCradle {
   rewriteRuleMapper: RewriteRuleMapper;
   chromeTabsGateway: ChromeTabsGateway;
   rewriteRuleMessagingService: RewriteRuleMessagingService;
+
+  // Delete Rule feature
+  deleteRuleControllerFactory: IDeleteRuleControllerFactory;
 }
 
 // Token mappings for interface-based resolution (legacy compatibility)
@@ -151,6 +163,7 @@ type InterfaceToken =
   | 'IChromeRuntimeService'
   | 'IGetSelectionService'
   | 'IToggleRuleActiveControllerFactory'
+  | 'IDeleteRuleControllerFactory'
   | 'ITabsGateway'
   | 'IRewriteRuleMessagingPort';
 
@@ -164,6 +177,7 @@ const interfaceToKeyMap: Record<InterfaceToken, keyof ContainerCradle> = {
   'IChromeRuntimeService': 'chromeRuntimeService',
   'IGetSelectionService': 'getSelectionService',
   'IToggleRuleActiveControllerFactory': 'toggleRuleActiveControllerFactory',
+  'IDeleteRuleControllerFactory': 'deleteRuleControllerFactory',
   'ITabsGateway': 'chromeTabsGateway',
   'IRewriteRuleMessagingPort': 'rewriteRuleMessagingService'
 };
@@ -181,6 +195,7 @@ const classToKeyMap = new Map<Function, keyof ContainerCradle>([
   [ChromeTabsService, 'chromeTabsService'],
   [ChromeCurrentTabService, 'chromeCurrentTabService'],
   [ToggleRuleActiveControllerFactory, 'toggleRuleActiveControllerFactory'],
+  [DeleteRuleControllerFactory, 'deleteRuleControllerFactory'],
   [RewriteRuleMapper, 'rewriteRuleMapper'],
   [ChromeTabsGateway, 'chromeTabsGateway'],
   [RewriteRuleMessagingService, 'rewriteRuleMessagingService']
@@ -199,6 +214,7 @@ interface Container {
   resolve(token: typeof ChromeTabsService): ChromeTabsService;
   resolve(token: typeof ChromeCurrentTabService): ChromeCurrentTabService;
   resolve(token: typeof ToggleRuleActiveControllerFactory): ToggleRuleActiveControllerFactory;
+  resolve(token: typeof DeleteRuleControllerFactory): DeleteRuleControllerFactory;
   resolve(token: typeof RewriteRuleMapper): RewriteRuleMapper;
   resolve(token: typeof ChromeTabsGateway): ChromeTabsGateway;
   resolve(token: typeof RewriteRuleMessagingService): RewriteRuleMessagingService;

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/concrete-class-registration-completeness.test.ts
@@ -13,6 +13,7 @@ import { RewriteRuleMessagingService } from 'src/frameworks-and-drivers/messagin
 import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
 import { ChromeCurrentTabService } from 'src/infrastructure/browser/tabs/ChromeCurrentTabService';
 import { ChromeTabsService } from 'src/infrastructure/browser/tabs/ChromeTabsService';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
 import { ToggleRuleActiveControllerFactory } from 'src/interface-adapters/factories/ToggleRuleActiveControllerFactory';
 import { RewriteRuleMapper } from 'src/interface-adapters/mappers/RewriteRuleMapper';
 
@@ -96,6 +97,11 @@ describe('DI Container - 具体クラス登録確認テスト (Awilix)', () => {
       description: 'ToggleRuleActiveControllerFactoryを解決できること',
       input: { classToken: ToggleRuleActiveControllerFactory },
       expected: { className: 'ToggleRuleActiveControllerFactory' }
+    },
+    {
+      description: 'DeleteRuleControllerFactoryを解決できること',
+      input: { classToken: DeleteRuleControllerFactory },
+      expected: { className: 'DeleteRuleControllerFactory' }
     },
     {
       description: 'RewriteRuleMapperを解決できること',

--- a/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/infrastructure/di/container/interface-registration-completeness.test.ts
@@ -83,6 +83,11 @@ describe('DI Container - インターフェース登録確認テスト (Awilix)'
       expected: { implementationName: 'ToggleRuleActiveControllerFactory' }
     },
     {
+      description: 'IDeleteRuleControllerFactoryをDeleteRuleControllerFactoryに解決できること',
+      input: { interfaceToken: 'IDeleteRuleControllerFactory' as const },
+      expected: { implementationName: 'DeleteRuleControllerFactory' }
+    },
+    {
       description: 'ITabsGatewayをChromeTabsGatewayに解決できること',
       input: { interfaceToken: 'ITabsGateway' as const },
       expected: { implementationName: 'ChromeTabsGateway' }


### PR DESCRIPTION
## Summary
This PR registers the `DeleteRuleControllerFactory` in the dependency injection container, enabling the delete rule feature to be properly resolved throughout the application.

## Key Changes
- Added imports for `DeleteRuleControllerFactory` and `IDeleteRuleControllerFactory`
- Instantiated `deleteRuleControllerFactory` with required dependencies (`rewriteRuleRepository` and `chromeTabsGateway`)
- Registered the factory in the Awilix container as a singleton value
- Updated the `ContainerCradle` interface to include the new factory type
- Added `IDeleteRuleControllerFactory` to the `InterfaceToken` union type
- Updated `interfaceToKeyMap` to map the interface token to the container key
- Updated `classToKeyMap` to enable class-based resolution of `DeleteRuleControllerFactory`
- Added overload to the `Container.resolve()` interface for type-safe resolution

## Implementation Details
The factory follows the same pattern as the existing `ToggleRuleActiveControllerFactory`, receiving the same core dependencies (`rewriteRuleRepository` and `chromeTabsGateway`) to manage rule operations and communicate with browser tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **新機能**
  * ルール削除機能が追加され、既存のルール管理（有効化／書き換え）と共に利用可能になりました。
* **テスト**
  * 依存性注入コンテナの登録と解決に関するユニットテストが拡充され、削除機能の解決性を確認するケースが追加されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->