### PR TITLE
Add comprehensive integration tests for delete-rule feature

### DIFF
--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/data-integrity.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/data-integrity.test.ts
@@ -1,0 +1,151 @@
+/**
+ * delete-rule 結合テスト - データ整合性
+ * Factory → Controller → DB までのデータフローが整合していることを検証
+ *
+ * 1. ルールA削除後、ルールBが正常に取得できる（他ルール不変）
+ * 2. 削除前後で件数が1減少することを確認（全件数確認）
+ */
+import 'tests/integration/delete-rule/setup';
+
+import { createMockTabsGateway } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/mocks/createMockTabsGateway';
+import { createTestRule } from 'tests/integration/delete-rule/helpers/createTestRule';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
+import { dexieDatabase } from 'src/infrastructure/persistence/indexeddb/DexieDatabase';
+import { IDeleteRuleController } from 'src/interface-adapters/controllers/IDeleteRuleController';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+
+describe('delete-rule 結合テスト - データ整合性', () => {
+  let repository: DexieRewriteRuleRepository;
+  let mockTabsGateway: ITabsGateway;
+  let controller: IDeleteRuleController;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await dexieDatabase.rewriteRules.clear();
+    repository = new DexieRewriteRuleRepository();
+    mockTabsGateway = createMockTabsGateway();
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    controller = factory.create(vi.fn(), vi.fn());
+  });
+
+  it('ルールA削除後、ルールBが正常に取得できる', async () => {
+    // Arrange: 2つのルールを作成
+    const ruleA = createTestRule({
+      oldString: 'ruleA-old',
+      newString: 'ruleA-new',
+      urlPattern: 'https://siteA.com',
+      isRegex: false,
+      isActive: true,
+    });
+    const ruleB = createTestRule({
+      oldString: 'ruleB-old',
+      newString: 'ruleB-new',
+      urlPattern: 'https://siteB.com',
+      isRegex: true,
+      isActive: false,
+    });
+
+    await repository.create(ruleA);
+    await repository.create(ruleB);
+
+    const createdRules = await repository.getAll();
+    const rulesArray = createdRules.toArray();
+    const ruleAInDb = rulesArray.find((r) => r.oldString === 'ruleA-old')!;
+    const ruleBInDb = rulesArray.find((r) => r.oldString === 'ruleB-old')!;
+
+    // Act: ルールAを削除
+    await controller.deleteRule(ruleAInDb.id);
+
+    // Assert: ルールBは正常に取得できる
+    const ruleBAfterDelete = await repository.getById(ruleBInDb.id);
+    expect(ruleBAfterDelete.id).toBe(ruleBInDb.id);
+    expect(ruleBAfterDelete.oldString).toBe('ruleB-old');
+    expect(ruleBAfterDelete.newString).toBe('ruleB-new');
+    expect(ruleBAfterDelete.urlPattern).toBe('https://siteB.com');
+    expect(ruleBAfterDelete.isRegex).toBe(true);
+    expect(ruleBAfterDelete.isActive).toBe(false);
+  });
+
+  it('削除前後で件数が1減少することを確認', async () => {
+    // Arrange: 3つのルールを作成
+    const rule1 = createTestRule({
+      oldString: 'rule1-old',
+      isActive: true,
+    });
+    const rule2 = createTestRule({
+      oldString: 'rule2-old',
+      isActive: true,
+    });
+    const rule3 = createTestRule({
+      oldString: 'rule3-old',
+      isActive: false,
+    });
+
+    await repository.create(rule1);
+    await repository.create(rule2);
+    await repository.create(rule3);
+
+    const rulesBefore = await repository.getAll();
+    const countBefore = rulesBefore.toArray().length;
+    expect(countBefore).toBe(3);
+
+    const ruleToDelete = rulesBefore.toArray().find((r) => r.oldString === 'rule2-old')!;
+
+    // Act: 1つのルールを削除
+    await controller.deleteRule(ruleToDelete.id);
+
+    // Assert: 件数が1減少
+    const rulesAfter = await repository.getAll();
+    const countAfter = rulesAfter.toArray().length;
+    expect(countAfter).toBe(countBefore - 1);
+    expect(countAfter).toBe(2);
+
+    // Assert: 残りのルールが正しい
+    const remainingOldStrings = rulesAfter.toArray().map((r) => r.oldString);
+    expect(remainingOldStrings).toContain('rule1-old');
+    expect(remainingOldStrings).toContain('rule3-old');
+    expect(remainingOldStrings).not.toContain('rule2-old');
+  });
+
+  it('他のルールのプロパティが変更されない', async () => {
+    // Arrange: 2つのルールを作成
+    const ruleToDelete = createTestRule({
+      oldString: 'delete-me',
+      newString: 'delete-new',
+      urlPattern: 'https://delete.com',
+      isRegex: false,
+      isActive: true,
+    });
+    const ruleToKeep = createTestRule({
+      oldString: 'keep-me',
+      newString: 'keep-new',
+      urlPattern: 'https://keep.com',
+      isRegex: true,
+      isActive: false,
+    });
+
+    await repository.create(ruleToDelete);
+    await repository.create(ruleToKeep);
+
+    const createdRules = await repository.getAll();
+    const rulesArray = createdRules.toArray();
+    const deleteTarget = rulesArray.find((r) => r.oldString === 'delete-me')!;
+    const keepTarget = rulesArray.find((r) => r.oldString === 'keep-me')!;
+
+    // Act: 1つのルールを削除
+    await controller.deleteRule(deleteTarget.id);
+
+    // Assert: 残ったルールのプロパティが完全に保持される
+    const keptRule = await repository.getById(keepTarget.id);
+    expect(keptRule.oldString).toBe('keep-me');
+    expect(keptRule.newString).toBe('keep-new');
+    expect(keptRule.urlPattern).toBe('https://keep.com');
+    expect(keptRule.isRegex).toBe(true);
+    expect(keptRule.isActive).toBe(false);
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/error-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/error-cases.test.ts
@@ -1,0 +1,146 @@
+/**
+ * delete-rule 結合テスト - エラー系
+ * Factory → Controller経由で存在しないルールIDを指定した場合のエラーハンドリングを検証
+ *
+ * 1. 存在しないruleIdでonErrorコールバックが呼ばれる
+ * 2. エラー時にDBが変更されない
+ * 3. エラー時にTabsGatewayが呼ばれない
+ */
+import 'tests/integration/delete-rule/setup';
+
+import { createMockTabsGateway } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/mocks/createMockTabsGateway';
+import { createTestRule } from 'tests/integration/delete-rule/helpers/createTestRule';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
+import { dexieDatabase } from 'src/infrastructure/persistence/indexeddb/DexieDatabase';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+
+describe('delete-rule 結合テスト - エラー系', () => {
+  let repository: DexieRewriteRuleRepository;
+  let mockTabsGateway: ITabsGateway;
+  let onSuccess: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await dexieDatabase.rewriteRules.clear();
+    repository = new DexieRewriteRuleRepository();
+    mockTabsGateway = createMockTabsGateway();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+  });
+
+  it('存在しないruleIdでonErrorコールバックが呼ばれる', async () => {
+    // Arrange: DBは空のまま
+    const nonExistentRuleId = 99999;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(nonExistentRuleId);
+
+    // Assert
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      nonExistentRuleId,
+      expect.stringContaining(String(nonExistentRuleId))
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(mockTabsGateway.reloadMatchingTabs).not.toHaveBeenCalled();
+  });
+
+  it('存在するルールがある状態で存在しないIDを指定するとonErrorコールバックが呼ばれる', async () => {
+    // Arrange: 1つのルールを作成
+    const existingRule = createTestRule({ isActive: true });
+    await repository.create(existingRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+    const nonExistentRuleId = ruleInDb.id + 1000;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(nonExistentRuleId);
+
+    // Assert
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('エラー時に既存のDBデータが変更されない', async () => {
+    // Arrange: 複数のルールを作成
+    const rule1 = createTestRule({
+      oldString: 'rule1-old',
+      isActive: true,
+    });
+    const rule2 = createTestRule({
+      oldString: 'rule2-old',
+      isActive: false,
+    });
+
+    await repository.create(rule1);
+    await repository.create(rule2);
+
+    const createdRules = await repository.getAll();
+    const countBefore = createdRules.toArray().length;
+    const nonExistentRuleId = 99999;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: 存在しないIDで削除試行
+    await controller.deleteRule(nonExistentRuleId);
+
+    // Assert: DBの状態が変更されていない
+    const rulesAfter = await repository.getAll();
+    const rulesArrayAfter = rulesAfter.toArray();
+
+    expect(rulesArrayAfter).toHaveLength(countBefore);
+
+    const rule1After = rulesArrayAfter.find((r) => r.oldString === 'rule1-old')!;
+    const rule2After = rulesArrayAfter.find((r) => r.oldString === 'rule2-old')!;
+
+    expect(rule1After.isActive).toBe(true);
+    expect(rule2After.isActive).toBe(false);
+  });
+
+  it('エラー時にTabsGatewayが呼ばれない', async () => {
+    // Arrange
+    const nonExistentRuleId = 99999;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(nonExistentRuleId);
+
+    // Assert
+    expect(mockTabsGateway.reloadMatchingTabs).not.toHaveBeenCalled();
+  });
+
+  it('エラーメッセージにruleIdが含まれる', async () => {
+    // Arrange
+    const nonExistentRuleId = 12345;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(nonExistentRuleId);
+
+    // Assert: エラーメッセージにIDが含まれる
+    expect(onError).toHaveBeenCalledWith(
+      nonExistentRuleId,
+      expect.stringContaining('12345')
+    );
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/helpers/createTestRule.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/helpers/createTestRule.ts
@@ -1,0 +1,24 @@
+import { RewriteRule } from 'src/enterprise-business-rules/entities/RewriteRule/RewriteRule';
+
+/**
+ * テスト用RewriteRuleを生成するヘルパー
+ * @param overrides 上書きするプロパティ
+ * @returns RewriteRuleインスタンス
+ */
+export const createTestRule = (overrides: {
+  id?: number;
+  oldString?: string;
+  newString?: string;
+  urlPattern?: string;
+  isRegex?: boolean;
+  isActive?: boolean;
+} = {}): RewriteRule => {
+  return new RewriteRule(
+    overrides.id ?? 1,
+    overrides.oldString ?? 'oldString',
+    overrides.newString ?? 'newString',
+    overrides.urlPattern ?? 'https://example.com',
+    overrides.isRegex ?? false,
+    overrides.isActive ?? true
+  );
+};

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/normal-cases.test.ts
@@ -1,0 +1,89 @@
+/**
+ * delete-rule 結合テスト - 正常系
+ * Factory → Controller → UseCase → Repository → DB → Presenter の一連フローを検証
+ *
+ * 1. ルールID指定で削除、getByIdで取得失敗を確認
+ * 2. 削除後にgetAllで該当ルールが含まれないことを確認
+ */
+import 'tests/integration/delete-rule/setup';
+
+import { createMockTabsGateway } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/mocks/createMockTabsGateway';
+import { createTestRule } from 'tests/integration/delete-rule/helpers/createTestRule';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { RewriteRuleNotFoundError } from 'src/domain/errors/RewriteRuleNotFoundError';
+import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
+import { dexieDatabase } from 'src/infrastructure/persistence/indexeddb/DexieDatabase';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+
+describe('delete-rule 結合テスト - 正常系', () => {
+  let repository: DexieRewriteRuleRepository;
+  let mockTabsGateway: ITabsGateway;
+  let onSuccess: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await dexieDatabase.rewriteRules.clear();
+    repository = new DexieRewriteRuleRepository();
+    mockTabsGateway = createMockTabsGateway();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+  });
+
+  it('ルールID指定で削除、getByIdで取得失敗を確認', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({
+      oldString: 'pattern-to-delete',
+      urlPattern: 'https://example.com',
+      isActive: true,
+    });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: DBからルールが削除されている（getByIdがエラーを投げる）
+    await expect(repository.getById(ruleInDb.id)).rejects.toThrow(RewriteRuleNotFoundError);
+
+    // Assert: 成功コールバックが呼ばれる
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(ruleInDb.id);
+
+    // Assert: TabsGatewayが呼ばれる
+    expect(mockTabsGateway.reloadMatchingTabs).toHaveBeenCalledTimes(1);
+
+    // Assert: エラーコールバックは呼ばれない
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('削除後にgetAllで該当ルールが含まれないことを確認', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({
+      oldString: 'pattern-to-delete',
+      urlPattern: 'https://example.com',
+      isActive: true,
+    });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: getAllで空の結果が返る
+    const remainingRules = await repository.getAll();
+    expect(remainingRules.toArray()).toHaveLength(0);
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/partial-success.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/partial-success.test.ts
@@ -1,0 +1,187 @@
+/**
+ * delete-rule 結合テスト - 部分的成功
+ * ルール削除成功後にタブリロードが失敗した場合の挙動を検証
+ *
+ * DeleteRuleInteractorの実装より:
+ * - 削除成功後、tabsGateway.reloadMatchingTabs()の前にpresenter.present()を呼び出す
+ * - これにより、タブリロードが失敗しても削除成功をUIに反映できる
+ *
+ * 部分的成功の挙動:
+ * 1. onSuccessが呼ばれる（削除成功を通知）
+ * 2. onErrorが呼ばれる（タブリロード失敗を通知）
+ * 3. DBからはルールが削除されている
+ */
+import 'tests/integration/delete-rule/setup';
+
+import { createFailingTabsGatewayMock } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/createFailingTabsGatewayMock';
+import { createTestRule } from 'tests/integration/delete-rule/helpers/createTestRule';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RewriteRuleNotFoundError } from 'src/domain/errors/RewriteRuleNotFoundError';
+import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
+import { dexieDatabase } from 'src/infrastructure/persistence/indexeddb/DexieDatabase';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+
+describe('delete-rule 結合テスト - 部分的成功（タブリロード失敗）', () => {
+  let repository: DexieRewriteRuleRepository;
+  let onSuccess: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await dexieDatabase.rewriteRules.clear();
+    repository = new DexieRewriteRuleRepository();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+  });
+
+  it('タブリロード失敗時もonSuccessが呼ばれる（削除は成功）', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({ isActive: true });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // タブリロード失敗をシミュレートするモック
+    const failingTabsGateway = createFailingTabsGatewayMock('Tab reload failed');
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, failingTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: onSuccessが呼ばれる
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(ruleInDb.id);
+  });
+
+  it('タブリロード失敗のエラーメッセージがonErrorで通知される', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({ isActive: true });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // タブリロード失敗をシミュレートするモック
+    const errorMessage = 'Failed to reload tabs';
+    const failingTabsGateway = createFailingTabsGatewayMock(errorMessage);
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, failingTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: onErrorが呼ばれ、エラーメッセージが渡される
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      ruleInDb.id,
+      expect.stringContaining(errorMessage)
+    );
+  });
+
+  it('タブリロード失敗してもDBからはルールが削除されている', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({
+      oldString: 'testOld',
+      newString: 'testNew',
+      isActive: true,
+    });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // タブリロード失敗をシミュレートするモック
+    const failingTabsGateway = createFailingTabsGatewayMock('Tab reload failed');
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, failingTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: DBからルールが削除されている
+    await expect(repository.getById(ruleInDb.id)).rejects.toThrow(RewriteRuleNotFoundError);
+
+    // Assert: getAllでも空
+    const remainingRules = await repository.getAll();
+    expect(remainingRules.toArray()).toHaveLength(0);
+  });
+
+  it('onSuccessとonErrorの両方が呼ばれる（部分的成功の定義）', async () => {
+    // Arrange: DBにテストデータを挿入
+    const initialRule = createTestRule({ isActive: true });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // タブリロード失敗をシミュレートするモック
+    const failingTabsGateway = createFailingTabsGatewayMock('Network error');
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, failingTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: 両方のコールバックが呼ばれる
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    // Assert: onSuccessには削除されたruleIdが渡される
+    expect(onSuccess).toHaveBeenCalledWith(ruleInDb.id);
+
+    // Assert: onErrorにはエラー情報が渡される
+    expect(onError).toHaveBeenCalledWith(
+      ruleInDb.id,
+      expect.any(String)
+    );
+  });
+
+  it('複数ルールがある場合、削除対象のみが削除され他は影響を受けない', async () => {
+    // Arrange: 2つのルールを作成
+    const ruleToDelete = createTestRule({
+      oldString: 'delete-me',
+      isActive: true,
+    });
+    const ruleToKeep = createTestRule({
+      oldString: 'keep-me',
+      isActive: false,
+    });
+
+    await repository.create(ruleToDelete);
+    await repository.create(ruleToKeep);
+
+    const createdRules = await repository.getAll();
+    const rulesArray = createdRules.toArray();
+    const deleteTarget = rulesArray.find((r) => r.oldString === 'delete-me')!;
+    const keepTarget = rulesArray.find((r) => r.oldString === 'keep-me')!;
+
+    // タブリロード失敗をシミュレートするモック
+    const failingTabsGateway = createFailingTabsGatewayMock('Tab reload failed');
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, failingTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act: Controller経由で削除操作
+    await controller.deleteRule(deleteTarget.id);
+
+    // Assert: 削除対象は削除されている
+    await expect(repository.getById(deleteTarget.id)).rejects.toThrow(RewriteRuleNotFoundError);
+
+    // Assert: 他のルールは影響を受けない
+    const keptRule = await repository.getById(keepTarget.id);
+    expect(keptRule.oldString).toBe('keep-me');
+    expect(keptRule.isActive).toBe(false);
+
+    // Assert: 件数が1減少
+    const remainingRules = await repository.getAll();
+    expect(remainingRules.toArray()).toHaveLength(1);
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/presenter-output.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/presenter-output.test.ts
@@ -1,0 +1,138 @@
+/**
+ * delete-rule 結合テスト - Presenter出力整合性
+ * Factory → Controller → Presenterを通じてView層に正しいデータが渡されることを検証
+ *
+ * 1. 削除成功時にonSuccessコールバックが呼ばれる
+ * 2. onSuccessに削除されたruleIdが含まれる
+ */
+import 'tests/integration/delete-rule/setup';
+
+import { createMockTabsGateway } from 'tests/frameworks-and-drivers/browser/ChromeTabsGateway/mocks/createMockTabsGateway';
+import { createTestRule } from 'tests/integration/delete-rule/helpers/createTestRule';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ITabsGateway } from 'src/application-business-rules/ports/gateway/ITabsGateway';
+import { DexieRewriteRuleRepository } from 'src/frameworks-and-drivers/persistence/DexieRewriteRuleRepository';
+import { dexieDatabase } from 'src/infrastructure/persistence/indexeddb/DexieDatabase';
+import { DeleteRuleControllerFactory } from 'src/interface-adapters/factories/DeleteRuleControllerFactory';
+
+describe('delete-rule 結合テスト - Presenter出力整合性', () => {
+  let repository: DexieRewriteRuleRepository;
+  let mockTabsGateway: ITabsGateway;
+  let onSuccess: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await dexieDatabase.rewriteRules.clear();
+    repository = new DexieRewriteRuleRepository();
+    mockTabsGateway = createMockTabsGateway();
+    onSuccess = vi.fn();
+    onError = vi.fn();
+  });
+
+  it('削除成功時にonSuccessコールバックが正確に1回呼び出される', async () => {
+    // Arrange
+    const initialRule = createTestRule({ isActive: true });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('onSuccessに削除されたruleIdが渡される', async () => {
+    // Arrange
+    const initialRule = createTestRule({
+      oldString: 'testOld',
+      newString: 'testNew',
+      urlPattern: 'https://test.com',
+      isRegex: false,
+      isActive: true,
+    });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert
+    expect(onSuccess).toHaveBeenCalledWith(ruleInDb.id);
+  });
+
+  it('複数ルールから1つ削除時、削除されたruleIdのみがonSuccessに渡される', async () => {
+    // Arrange: 3つのルールを作成
+    const rule1 = createTestRule({
+      oldString: 'rule1-old',
+      isActive: true,
+    });
+    const rule2 = createTestRule({
+      oldString: 'rule2-old',
+      isActive: true,
+    });
+    const rule3 = createTestRule({
+      oldString: 'rule3-old',
+      isActive: false,
+    });
+
+    await repository.create(rule1);
+    await repository.create(rule2);
+    await repository.create(rule3);
+
+    const createdRules = await repository.getAll();
+    const rulesArray = createdRules.toArray();
+    const ruleToDelete = rulesArray.find((r) => r.oldString === 'rule2-old')!;
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(ruleToDelete.id);
+
+    // Assert: 削除されたruleIdのみが渡される
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(ruleToDelete.id);
+  });
+
+  it('TabsGatewayが削除されたルールで呼び出される', async () => {
+    // Arrange
+    const initialRule = createTestRule({
+      urlPattern: 'https://reload-target.com',
+      isActive: true,
+    });
+    await repository.create(initialRule);
+    const createdRules = await repository.getAll();
+    const ruleInDb = createdRules.toArray()[0];
+
+    // Factory経由でControllerを取得（UIと同じフロー）
+    const factory = new DeleteRuleControllerFactory(repository, mockTabsGateway);
+    const controller = factory.create(onSuccess, onError);
+
+    // Act
+    await controller.deleteRule(ruleInDb.id);
+
+    // Assert: TabsGatewayが呼ばれる
+    expect(mockTabsGateway.reloadMatchingTabs).toHaveBeenCalledTimes(1);
+    expect(mockTabsGateway.reloadMatchingTabs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ruleInDb.id,
+        urlPattern: 'https://reload-target.com',
+      })
+    );
+  });
+});

--- a/host-frontend-root/frontend-src-root/tests/integration/delete-rule/setup.ts
+++ b/host-frontend-root/frontend-src-root/tests/integration/delete-rule/setup.ts
@@ -1,0 +1,5 @@
+/**
+ * delete-rule 結合テスト セットアップファイル
+ * fake-indexeddb/auto を使用してIndexedDBを自動セットアップ
+ */
+import 'fake-indexeddb/auto';


### PR DESCRIPTION
## Summary
This PR adds a complete suite of integration tests for the delete-rule feature, covering the entire data flow from Factory → Controller → UseCase → Repository → Database → Presenter.

## Key Changes
- **Normal cases** (`normal-cases.test.ts`): Validates successful rule deletion through the complete flow, including database state verification and callback invocation
- **Error cases** (`error-cases.test.ts`): Tests error handling when attempting to delete non-existent rules, ensuring database integrity and proper error callbacks
- **Data integrity** (`data-integrity.test.ts`): Verifies that deleting one rule doesn't affect other rules, and confirms correct count changes
- **Partial success** (`partial-success.test.ts`): Tests the scenario where rule deletion succeeds but tab reloading fails, ensuring both success and error callbacks are invoked appropriately
- **Presenter output** (`presenter-output.test.ts`): Validates that the correct data (deleted ruleId) is passed to UI callbacks
- **Test helpers** (`helpers/createTestRule.ts`): Utility function for creating test RewriteRule instances with customizable properties
- **Test setup** (`setup.ts`): Configures fake-indexeddb for test environment

## Notable Implementation Details
- Tests use `DeleteRuleControllerFactory` to follow the same initialization flow as the actual UI
- Mock `ITabsGateway` is used to verify tab reload behavior without side effects
- Tests verify both positive and negative paths through the application layers
- Partial success scenario demonstrates the architecture's resilience: deletion succeeds even if subsequent tab reload fails
- All tests properly clean up the database state between runs using `beforeEach` hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * ルール削除機能の包括的な統合テストスイートを追加しました。データ整合性、エラーハンドリング、正常系、部分成功シナリオ、プレゼンター出力を検証するテストケースを含みます。テストヘルパー関数とセットアップファイルも追加されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->