### PR TITLE
Test: Complete RewriteRuleMapper.toDto normal cases test

### DIFF
--- a/docs/user-stories/user-story-005/README.md
+++ b/docs/user-stories/user-story-005/README.md
@@ -31,7 +31,7 @@
 |---|-------------|------|
 | 1 | `tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts` | ⬜ 未着手 |
 | 2 | `tests/unit/interface-adapters/presenters/ToggleRuleActivePresenter/present/normal-cases.test.ts` | ⬜ 未着手 |
-| 3 | `tests/unit/interface-adapters/mappers/RewriteRuleMapper/toDto/normal-cases.test.ts` | ⬜ 未着手 |
+| 3 | `tests/unit/interface-adapters/mappers/RewriteRuleMapper/toDto/normal-cases.test.ts` | ✅ 完了 |
 
 #### 2. application-business-rules層（7ファイル）
 

--- a/docs/user-stories/user-story-005/README.md
+++ b/docs/user-stories/user-story-005/README.md
@@ -29,72 +29,72 @@
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 1 | `tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts` | ⬜ 未着手 |
-| 2 | `tests/unit/interface-adapters/presenters/ToggleRuleActivePresenter/present/normal-cases.test.ts` | ⬜ 未着手 |
+| 1 | `tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts` | ✅ 完了 |
+| 2 | `tests/unit/interface-adapters/presenters/ToggleRuleActivePresenter/present/normal-cases.test.ts` | ✅ 完了 |
 | 3 | `tests/unit/interface-adapters/mappers/RewriteRuleMapper/toDto/normal-cases.test.ts` | ✅ 完了 |
 
 #### 2. application-business-rules層（7ファイル）
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 4 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/normal-cases.test.ts` | ⬜ 未着手 |
-| 5 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/error-cases.test.ts` | ⬜ 未着手 |
-| 6 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/partial-success-cases.test.ts` | ⬜ 未着手 |
-| 7 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/normal-cases.test.ts` | ⬜ 未着手 |
-| 8 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/error-cases.test.ts` | ⬜ 未着手 |
-| 9 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/partial-success-cases.test.ts` | ⬜ 未着手 |
-| 10 | `tests/unit/application-business-rules/dto/output/ToggleRuleActiveOutputData/constructor/normal-cases.test.ts` | ⬜ 未着手 |
+| 4 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/normal-cases.test.ts` | ✅ 完了 |
+| 5 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/error-cases.test.ts` | ✅ 完了 |
+| 6 | `tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/partial-success-cases.test.ts` | ✅ 完了 |
+| 7 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/normal-cases.test.ts` | ✅ 完了 |
+| 8 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/error-cases.test.ts` | ✅ 完了 |
+| 9 | `tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/partial-success-cases.test.ts` | ✅ 完了 |
+| 10 | `tests/unit/application-business-rules/dto/output/ToggleRuleActiveOutputData/constructor/normal-cases.test.ts` | ✅ 完了 |
 
 #### 3. application層（2ファイル）
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 11 | `tests/unit/application/usecases/rule/LoadRewriteRuleForEditUseCase/execute/normal-cases.test.ts` | ⬜ 未着手 |
-| 12 | `tests/unit/application/usecases/rule/UpdateRewriteRuleUseCase/execute/normal-cases.test.ts` | ⬜ 未着手 |
+| 11 | `tests/unit/application/usecases/rule/LoadRewriteRuleForEditUseCase/execute/normal-cases.test.ts` | ✅ 完了 |
+| 12 | `tests/unit/application/usecases/rule/UpdateRewriteRuleUseCase/execute/normal-cases.test.ts` | ✅ 完了 |
 
 #### 4. enterprise-business-rules層（5ファイル）
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 13 | `tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-false.test.ts` | ⬜ 未着手 |
-| 14 | `tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-true.test.ts` | ⬜ 未着手 |
-| 15 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/normal-cases.test.ts` | ⬜ 未着手 |
-| 16 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/immutability.test.ts` | ⬜ 未着手 |
-| 17 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/property-preservation.test.ts` | ⬜ 未着手 |
+| 13 | `tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-false.test.ts` | ✅ 完了 |
+| 14 | `tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-true.test.ts` | ✅ 完了 |
+| 15 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/normal-cases.test.ts` | ✅ 完了 |
+| 16 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/immutability.test.ts` | ✅ 完了 |
+| 17 | `tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/property-preservation.test.ts` | ✅ 完了 |
 
 #### 5. domain層（17ファイル）
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 18 | `tests/unit/domain/value-objects/Tab/matchesRule/normal-cases.test.ts` | ⬜ 未着手 |
-| 19 | `tests/unit/domain/value-objects/Tabs/filterByRule/normal-cases.test.ts` | ⬜ 未着手 |
-| 20 | `tests/unit/domain/value-objects/RewriteRules/applyRulesWithDomDiffer/normal-cases.test.ts` | ⬜ 未着手 |
-| 21 | `tests/unit/domain/value-objects/RewriteRules/toArray/normal-cases.test.ts` | ⬜ 未着手 |
-| 22 | `tests/unit/domain/value-objects/RewriteRules/constructor/normal-cases.test.ts` | ⬜ 未着手 |
-| 23 | `tests/unit/domain/entities/DomDiffer/basic-replacement.test.ts` | ⬜ 未着手 |
-| 24 | `tests/unit/domain/entities/DomDiffer/normal-replacement.test.ts` | ⬜ 未着手 |
-| 25 | `tests/unit/domain/entities/DomDiffer/regex-replacement.test.ts` | ⬜ 未着手 |
-| 26 | `tests/unit/domain/entities/DomDiffer/regex-capture-group.test.ts` | ⬜ 未着手 |
-| 27 | `tests/unit/domain/entities/DomDiffer/simple-element-replacement.test.ts` | ⬜ 未着手 |
-| 28 | `tests/unit/domain/entities/DomDiffer/string-pattern-replacement.test.ts` | ⬜ 未着手 |
-| 29 | `tests/unit/domain/entities/RewriteRule/addHtmlWhitespaceIgnoringPattern/reflection-tests.test.ts` | ⬜ 未着手 |
-| 30 | `tests/unit/domain/entities/RewriteRule/createRedundantPattern/regex-pattern.test.ts` | ⬜ 未着手 |
-| 31 | `tests/unit/domain/entities/RewriteRule/createRedundantPattern/string-pattern.test.ts` | ⬜ 未着手 |
-| 32 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/exact-pattern-matching.test.ts` | ⬜ 未着手 |
-| 33 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/regex-pattern-matching.test.ts` | ⬜ 未着手 |
-| 34 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/Abend/error-handling.test.ts` | ⬜ 未着手 |
+| 18 | `tests/unit/domain/value-objects/Tab/matchesRule/normal-cases.test.ts` | ✅ 完了 |
+| 19 | `tests/unit/domain/value-objects/Tabs/filterByRule/normal-cases.test.ts` | ✅ 完了 |
+| 20 | `tests/unit/domain/value-objects/RewriteRules/applyRulesWithDomDiffer/normal-cases.test.ts` | ✅ 完了 |
+| 21 | `tests/unit/domain/value-objects/RewriteRules/toArray/normal-cases.test.ts` | ✅ 完了 |
+| 22 | `tests/unit/domain/value-objects/RewriteRules/constructor/normal-cases.test.ts` | ✅ 完了 |
+| 23 | `tests/unit/domain/entities/DomDiffer/basic-replacement.test.ts` | ✅ 完了 |
+| 24 | `tests/unit/domain/entities/DomDiffer/normal-replacement.test.ts` | ✅ 完了 |
+| 25 | `tests/unit/domain/entities/DomDiffer/regex-replacement.test.ts` | ✅ 完了 |
+| 26 | `tests/unit/domain/entities/DomDiffer/regex-capture-group.test.ts` | ✅ 完了 |
+| 27 | `tests/unit/domain/entities/DomDiffer/simple-element-replacement.test.ts` | ✅ 完了 |
+| 28 | `tests/unit/domain/entities/DomDiffer/string-pattern-replacement.test.ts` | ✅ 完了 |
+| 29 | `tests/unit/domain/entities/RewriteRule/addHtmlWhitespaceIgnoringPattern/reflection-tests.test.ts` | ✅ 完了 |
+| 30 | `tests/unit/domain/entities/RewriteRule/createRedundantPattern/regex-pattern.test.ts` | ✅ 完了 |
+| 31 | `tests/unit/domain/entities/RewriteRule/createRedundantPattern/string-pattern.test.ts` | ✅ 完了 |
+| 32 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/exact-pattern-matching.test.ts` | ✅ 完了 |
+| 33 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/regex-pattern-matching.test.ts` | ✅ 完了 |
+| 34 | `tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/Abend/error-handling.test.ts` | ✅ 完了 |
 
 #### 6. frameworks-and-drivers層（7ファイル）
 
 | # | ファイルパス | 状態 |
 |---|-------------|------|
-| 35 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getRulesMatchingUrl/normal-cases.test.ts` | ⬜ 未着手 |
-| 36 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getAll/normal-cases.test.ts` | ⬜ 未着手 |
-| 37 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/normal-cases.test.ts` | ⬜ 未着手 |
-| 38 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/Abend/error-cases.test.ts` | ⬜ 未着手 |
-| 39 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/update/normal-cases.test.ts` | ⬜ 未着手 |
-| 40 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/normal-cases.test.ts` | ⬜ 未着手 |
-| 41 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/error-cases.test.ts` | ⬜ 未着手 |
+| 35 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getRulesMatchingUrl/normal-cases.test.ts` | ✅ 完了 |
+| 36 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getAll/normal-cases.test.ts` | ✅ 完了 |
+| 37 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/normal-cases.test.ts` | ✅ 完了 |
+| 38 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/Abend/error-cases.test.ts` | ✅ 完了 |
+| 39 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/update/normal-cases.test.ts` | ✅ 完了 |
+| 40 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/normal-cases.test.ts` | ✅ 完了 |
+| 41 | `tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/error-cases.test.ts` | ✅ 完了 |
 
 ## タスク
 
@@ -102,7 +102,7 @@
 
 | # | タスク | 説明 | 状態 |
 |---|--------|------|------|
-| T-1 | 共通ファクトリの確認・整備 | `RewriteRule.fromParams()` の使用方法を確認し、テストで使用可能か検証する | ⬜ 未着手 |
+| T-1 | 共通ファクトリの確認・整備 | `RewriteRule.fromParams()` の使用方法を確認し、テストで使用可能か検証する | ✅ 完了 |
 
 ### フェーズ2: 層別リファクタリング（6タスク）
 
@@ -114,18 +114,18 @@
 
 | # | タスク | 対象ファイル数 | 状態 |
 |---|--------|---------------|------|
-| T-2 | interface-adapters層の修正 | 3ファイル | ⬜ 未着手 |
-| T-3 | application-business-rules層の修正 | 7ファイル | ⬜ 未着手 |
-| T-4 | application層の修正 | 2ファイル | ⬜ 未着手 |
-| T-5 | enterprise-business-rules層の修正 | 5ファイル | ⬜ 未着手 |
-| T-6 | domain層の修正 | 17ファイル | ⬜ 未着手 |
-| T-7 | frameworks-and-drivers層の修正 | 7ファイル | ⬜ 未着手 |
+| T-2 | interface-adapters層の修正 | 3ファイル | ✅ 完了 |
+| T-3 | application-business-rules層の修正 | 7ファイル | ✅ 完了 |
+| T-4 | application層の修正 | 2ファイル | ✅ 完了 |
+| T-5 | enterprise-business-rules層の修正 | 5ファイル | ✅ 完了 |
+| T-6 | domain層の修正 | 17ファイル | ✅ 完了 |
+| T-7 | frameworks-and-drivers層の修正 | 7ファイル | ✅ 完了 |
 
 ### フェーズ3: 検証（1タスク）
 
 | # | タスク | 説明 | 状態 |
 |---|--------|------|------|
-| T-8 | 全体テスト実行・確認 | `make testlint` を実行し、すべてのテストがパスすることを確認 | ⬜ 未着手 |
+| T-8 | 全体テスト実行・確認 | `make testlint` を実行し、すべてのテストがパスすることを確認 | ✅ 完了 |
 
 ## 受け入れ条件
 

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/dto/output/ToggleRuleActiveOutputData/constructor/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/dto/output/ToggleRuleActiveOutputData/constructor/normal-cases.test.ts
@@ -30,14 +30,13 @@ describe('ToggleRuleActiveOutputData.constructor - 正常系', () => {
       const urlPattern = 'https://example.com';
       const isRegex = false;
 
-      const rule = new RewriteRule(
-        ruleId,
+      const rule = RewriteRule.fromParams(ruleId, {
         oldString,
         newString,
         urlPattern,
         isRegex,
-        testCase.input.isActive
-      );
+        isActive: testCase.input.isActive,
+      });
 
       const outputData = new ToggleRuleActiveOutputData(rule);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/error-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/error-cases.test.ts
@@ -47,7 +47,13 @@ describe('DeleteRuleInteractor.execute - 異常系', () => {
       description: 'repository.deleteでエラーが発生した場合、presentErrorが呼び出される',
       input: { ruleId: 2 },
       setupMocks: (repository: IRewriteRuleRepository) => {
-        const rule = new RewriteRule(2, 'old', 'new', 'https://example.com', false, true);
+        const rule = RewriteRule.fromParams(2, {
+          oldString: 'old',
+          newString: 'new',
+          urlPattern: 'https://example.com',
+          isRegex: false,
+          isActive: true,
+        });
         (repository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
         (repository.delete as ReturnType<typeof vi.fn>).mockRejectedValue(
           new Error('削除に失敗しました')

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/normal-cases.test.ts
@@ -40,14 +40,13 @@ describe('DeleteRuleInteractor.execute - 正常系', () => {
 
   testCases.forEach((testCase) => {
     it(testCase.description, async () => {
-      const rule = new RewriteRule(
-        testCase.input.ruleId,
-        'oldString',
-        'newString',
-        'https://example.com',
-        false,
-        true
-      );
+      const rule = RewriteRule.fromParams(testCase.input.ruleId, {
+        oldString: 'oldString',
+        newString: 'newString',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+        isActive: true,
+      });
       (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
 
       const interactor = new DeleteRuleInteractor(

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/partial-success-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/DeleteRuleInteractor/execute/partial-success-cases.test.ts
@@ -43,14 +43,13 @@ describe('DeleteRuleInteractor.execute - 部分的成功', () => {
 
   testCases.forEach((testCase) => {
     it(testCase.description, async () => {
-      const rule = new RewriteRule(
-        testCase.input.ruleId,
-        'old',
-        'new',
-        'https://example.com',
-        false,
-        true
-      );
+      const rule = RewriteRule.fromParams(testCase.input.ruleId, {
+        oldString: 'old',
+        newString: 'new',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+        isActive: true,
+      });
       (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
       (mockRepository.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
       (mockTabsGateway.reloadMatchingTabs as ReturnType<typeof vi.fn>).mockRejectedValue(

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/error-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/error-cases.test.ts
@@ -47,7 +47,13 @@ describe('ToggleRuleActiveInteractor.execute - 異常系', () => {
       description: 'repository.updateでエラーが発生した場合、presentErrorが呼び出される',
       input: { ruleId: 2 },
       setupMocks: (repository: IRewriteRuleRepository) => {
-        const rule = new RewriteRule(2, 'old', 'new', 'https://example.com', false, true);
+        const rule = RewriteRule.fromParams(2, {
+          oldString: 'old',
+          newString: 'new',
+          urlPattern: 'https://example.com',
+          isRegex: false,
+          isActive: true,
+        });
         (repository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
         (repository.update as ReturnType<typeof vi.fn>).mockRejectedValue(
           new Error('更新に失敗しました')

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/normal-cases.test.ts
@@ -49,14 +49,13 @@ describe('ToggleRuleActiveInteractor.execute - 正常系', () => {
 
   testCases.forEach((testCase) => {
     it(testCase.description, async () => {
-      const originalRule = new RewriteRule(
-        testCase.input.ruleId,
-        'oldString',
-        'newString',
-        'https://example.com',
-        false,
-        testCase.initialIsActive
-      );
+      const originalRule = RewriteRule.fromParams(testCase.input.ruleId, {
+        oldString: 'oldString',
+        newString: 'newString',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+        isActive: testCase.initialIsActive,
+      });
       (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(originalRule);
 
       const interactor = new ToggleRuleActiveInteractor(

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/partial-success-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/interactors/ToggleRuleActiveInteractor/execute/partial-success-cases.test.ts
@@ -45,14 +45,13 @@ describe('ToggleRuleActiveInteractor.execute - 部分的成功', () => {
 
   testCases.forEach((testCase) => {
     it(testCase.description, async () => {
-      const rule = new RewriteRule(
-        testCase.input.ruleId,
-        'old',
-        'new',
-        'https://example.com',
-        false,
-        testCase.initialIsActive
-      );
+      const rule = RewriteRule.fromParams(testCase.input.ruleId, {
+        oldString: 'old',
+        newString: 'new',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+        isActive: testCase.initialIsActive,
+      });
       (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
       (mockRepository.update as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
       (mockTabsGateway.reloadMatchingTabs as ReturnType<typeof vi.fn>).mockRejectedValue(

--- a/host-frontend-root/frontend-src-root/tests/unit/application/usecases/rule/LoadRewriteRuleForEditUseCase/execute/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application/usecases/rule/LoadRewriteRuleForEditUseCase/execute/normal-cases.test.ts
@@ -26,24 +26,22 @@ describe('LoadRewriteRuleForEditUseCase.execute - 正常系', () => {
     {
       description: '存在するルールIDでルールが正常に取得できる',
       ruleId: 1,
-      mockRule: new RewriteRule(
-        1,
-        'oldText',
-        'newText',
-        'https://example.com',
-        false
-      ),
+      mockRule: RewriteRule.fromParams(1, {
+        oldString: 'oldText',
+        newString: 'newText',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+      }),
     },
     {
       description: '正規表現を含むルールが正常に取得できる',
       ruleId: 2,
-      mockRule: new RewriteRule(
-        2,
-        '\\d{4}-\\d{13}',
-        '<a href="https://example.com/$1">$1</a>',
-        'https://example.com',
-        true
-      ),
+      mockRule: RewriteRule.fromParams(2, {
+        oldString: '\\d{4}-\\d{13}',
+        newString: '<a href="https://example.com/$1">$1</a>',
+        urlPattern: 'https://example.com',
+        isRegex: true,
+      }),
     },
   ])('$description', async ({ ruleId, mockRule }) => {
     // Arrange

--- a/host-frontend-root/frontend-src-root/tests/unit/application/usecases/rule/UpdateRewriteRuleUseCase/execute/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application/usecases/rule/UpdateRewriteRuleUseCase/execute/normal-cases.test.ts
@@ -47,13 +47,12 @@ describe('UpdateRewriteRuleUseCase.execute - 正常系', () => {
         urlPattern: 'https://example.com',
         isRegex: false
       },
-      expectedRule: new RewriteRule(
-        1,
-        'oldText',
-        'newText',
-        'https://example.com',
-        false
-      ),
+      expectedRule: RewriteRule.fromParams(1, {
+        oldString: 'oldText',
+        newString: 'newText',
+        urlPattern: 'https://example.com',
+        isRegex: false,
+      }),
     },
     {
       description: '正規表現を含むルールが正常に更新できる',
@@ -64,13 +63,12 @@ describe('UpdateRewriteRuleUseCase.execute - 正常系', () => {
         urlPattern: 'https://example.com',
         isRegex: true
       },
-      expectedRule: new RewriteRule(
-        2,
-        '\\d{4}-\\d{13}',
-        '<a href="https://example.com/$1">$1</a>',
-        'https://example.com',
-        true
-      ),
+      expectedRule: RewriteRule.fromParams(2, {
+        oldString: '\\d{4}-\\d{13}',
+        newString: '<a href="https://example.com/$1">$1</a>',
+        urlPattern: 'https://example.com',
+        isRegex: true,
+      }),
     },
     {
       description: 'URLパターンを持つルールが正常に更新できる',
@@ -81,13 +79,12 @@ describe('UpdateRewriteRuleUseCase.execute - 正常系', () => {
         urlPattern: 'https://.*\\.example\\.com/.*',
         isRegex: false
       },
-      expectedRule: new RewriteRule(
-        3,
-        'search',
-        'replace',
-        'https://.*\\.example\\.com/.*',
-        false
-      ),
+      expectedRule: RewriteRule.fromParams(3, {
+        oldString: 'search',
+        newString: 'replace',
+        urlPattern: 'https://.*\\.example\\.com/.*',
+        isRegex: false,
+      }),
     },
   ])('$description', async ({ id, params, expectedRule }) => {
     // Arrange

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/basic-replacement.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/basic-replacement.test.ts
@@ -69,7 +69,7 @@ describe('DomDiffer - Basic Replacement', () => {
     it(description, () => {
       container.innerHTML = input.initialHtml;
 
-      const rule = new RewriteRule(1, input.oldString, input.newString, '');
+      const rule = RewriteRule.fromParams(1, { oldString: input.oldString, newString: input.newString, urlPattern: '', isRegex: false });
       const domDiffer = new DomDiffer(container, rule);
       domDiffer.applyRule(mockElementFactory);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/normal-replacement.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/normal-replacement.test.ts
@@ -140,7 +140,7 @@ describe('DomDiffer - Normal Replacement Cases', () => {
   normalReplacementTestCases.forEach(({ description, input, expected }) => {
     it(description, () => {
       container.innerHTML = input.initialHtml;
-      const rule = new RewriteRule(1, input.oldString, input.newString, '');
+      const rule = RewriteRule.fromParams(1, { oldString: input.oldString, newString: input.newString, urlPattern: '', isRegex: false });
       const domDiffer = new DomDiffer(container, rule);
       domDiffer.applyRule(mockElementFactory);
       expect(container.innerHTML).toBe(expected.html);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/regex-capture-group.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/regex-capture-group.test.ts
@@ -83,7 +83,7 @@ describe('DomDiffer - 正規表現キャプチャグループ置換', () => {
     it(description, () => {
       // Arrange
       container.innerHTML = input.initialHtml;
-      const rule = new RewriteRule(1, input.oldString, input.newString, '', true);
+      const rule = RewriteRule.fromParams(1, { oldString: input.oldString, newString: input.newString, urlPattern: '', isRegex: true });
 
       // Act
       const domDiffer = new DomDiffer(container, rule);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/regex-replacement.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/regex-replacement.test.ts
@@ -80,7 +80,7 @@ describe('DomDiffer - Regex Replacement Cases', () => {
   regexReplacementTestCases.forEach(({ description, input, expected }) => {
     it(description, () => {
       container.innerHTML = input.initialHtml;
-      const rule = new RewriteRule(1, input.oldString, input.newString, '', true); // isRegex = true
+      const rule = RewriteRule.fromParams(1, { oldString: input.oldString, newString: input.newString, urlPattern: '', isRegex: true });
       const domDiffer = new DomDiffer(container, rule);
       domDiffer.applyRule(mockElementFactory);
       expect(container.innerHTML).toBe(expected.html);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/simple-element-replacement.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/simple-element-replacement.test.ts
@@ -30,7 +30,7 @@ describe('DomDiffer - DOM Structure Preservation', () => {
       // Store reference to preserved element
       const preservedElement = container.querySelector('#keep-me');
 
-      const rule = new RewriteRule(1, '<div>Replace me</div>', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '<div>Replace me</div>', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const domDiffer = new DomDiffer(container, rule);
       domDiffer.applyRule(mockElementFactory);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/string-pattern-replacement.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/DomDiffer/string-pattern-replacement.test.ts
@@ -102,7 +102,7 @@ describe('DomDiffer - 通常文字列での置換の回帰テスト', () => {
     it(description, () => {
       // Arrange
       container.innerHTML = input.initialHtml;
-      const rule = new RewriteRule(1, input.oldString, input.newString, '', false); // isRegex = false
+      const rule = RewriteRule.fromParams(1, { oldString: input.oldString, newString: input.newString, urlPattern: '', isRegex: false });
 
       // Act
       const domDiffer = new DomDiffer(container, rule);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/Abend/error-handling.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/Abend/error-handling.test.ts
@@ -20,7 +20,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<div>Test</div>';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, '', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(false);
@@ -30,7 +30,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<div>Test</div>';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, '<div>Unclosed tag', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '<div>Unclosed tag', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(false);
@@ -40,7 +40,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<div>Test</div>';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, 'Just text with no elements', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: 'Just text with no elements', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(false);
@@ -52,7 +52,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<div></div>';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, '<div></div>', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '<div></div>', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(true);
@@ -62,7 +62,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<div>   </div>';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, '<div></div>', '<span>Replaced!</span>', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '<div></div>', newString: '<span>Replaced!</span>', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(true);
@@ -72,7 +72,7 @@ describe('ElementMatchesFlexiblePattern.exec() - Error Handling', () => {
       container.innerHTML = '<img src="test.jpg" alt="test">';
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(1, '<img src="test.jpg" alt="test">', '<img src="new.jpg" alt="new">', '');
+      const rule = RewriteRule.fromParams(1, { oldString: '<img src="test.jpg" alt="test">', newString: '<img src="new.jpg" alt="new">', urlPattern: '', isRegex: false });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       expect(matcher.exec()).toBe(true);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/exact-pattern-matching.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/exact-pattern-matching.test.ts
@@ -178,13 +178,12 @@ describe('ElementMatchesFlexiblePattern.exec() - Exact Pattern Matching (isRegex
       container.innerHTML = testCase.input.elementHTML;
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(
-        1,
-        testCase.input.rule.oldString,
-        testCase.input.rule.newString,
-        testCase.input.rule.urlPattern,
-        testCase.input.rule.isRegex
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: testCase.input.rule.oldString,
+        newString: testCase.input.rule.newString,
+        urlPattern: testCase.input.rule.urlPattern,
+        isRegex: testCase.input.rule.isRegex,
+      });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       // Act

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/regex-pattern-matching.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/ElementMatchesFlexiblePattern/exec/regex-pattern-matching.test.ts
@@ -178,13 +178,12 @@ describe('ElementMatchesFlexiblePattern.exec() - Regex Pattern Matching (isRegex
       container.innerHTML = testCase.input.elementHTML;
       const element = container.firstElementChild!;
       
-      const rule = new RewriteRule(
-        1,
-        testCase.input.rule.oldString,
-        testCase.input.rule.newString,
-        testCase.input.rule.urlPattern,
-        testCase.input.rule.isRegex
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: testCase.input.rule.oldString,
+        newString: testCase.input.rule.newString,
+        urlPattern: testCase.input.rule.urlPattern,
+        isRegex: testCase.input.rule.isRegex,
+      });
       const matcher = new ElementMatchesFlexiblePattern(element, rule);
       
       // Act

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/addHtmlWhitespaceIgnoringPattern/reflection-tests.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/addHtmlWhitespaceIgnoringPattern/reflection-tests.test.ts
@@ -53,7 +53,7 @@ const addHtmlWhitespaceIgnoringPatternCases = [
 describe('RewriteRule.addHtmlWhitespaceIgnoringPattern - リフレクションテスト', () => {
   addHtmlWhitespaceIgnoringPatternCases.forEach((testCase) => {
     it(testCase.description, () => {
-      const rule = new RewriteRule(1, 'test', 'replacement', '');
+      const rule = RewriteRule.fromParams(1, { oldString: 'test', newString: 'replacement', urlPattern: '', isRegex: false });
       
       // リフレクションを使ってプライベートメソッドにアクセス
       const result = (rule as any).addHtmlWhitespaceIgnoringPattern(testCase.input);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/createRedundantPattern/regex-pattern.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/createRedundantPattern/regex-pattern.test.ts
@@ -40,13 +40,12 @@ describe('RewriteRule.createRedundantPattern - 正規表現パターン', () => 
   regexPatternTestCases.forEach((testCase) => {
     it(testCase.description, () => {
       // Arrange
-      const rule = new RewriteRule(
-        1,
-        testCase.input.oldString,
-        'replacement',
-        '',
-        true
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: testCase.input.oldString,
+        newString: 'replacement',
+        urlPattern: '',
+        isRegex: true,
+      });
 
       // Act
       const result = rule.createRedundantPattern();

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/createRedundantPattern/string-pattern.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/entities/RewriteRule/createRedundantPattern/string-pattern.test.ts
@@ -70,13 +70,12 @@ describe('RewriteRule.createRedundantPattern - 文字列パターン', () => {
   stringPatternTestCases.forEach((testCase) => {
     it(testCase.description, () => {
       // Arrange
-      const rule = new RewriteRule(
-        1,
-        testCase.input.oldString,
-        'replacement',
-        '',
-        testCase.input.isRegex
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: testCase.input.oldString,
+        newString: 'replacement',
+        urlPattern: '',
+        isRegex: testCase.input.isRegex ?? false,
+      });
 
       // Act
       const result = rule.createRedundantPattern();

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/applyRulesWithDomDiffer/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/applyRulesWithDomDiffer/normal-cases.test.ts
@@ -27,9 +27,9 @@ describe('RewriteRules.applyRulesWithDomDiffer - 正常系', () => {
   it('全てのルールがDOMに適用される', () => {
     // Arrange
     const rulesObject: Record<string, RewriteRule> = {
-      1: new RewriteRule(1, '<p>Hello</p>', '<p>Hi</p>', 'https://example.com'),
-      2: new RewriteRule(2, '<span>World</span>', '<span>Universe</span>', 'https://example.com'),
-      3: new RewriteRule(3, '<div>Keep</div>', '<div>Changed</div>', 'https://other.com'),
+      1: RewriteRule.fromParams(1, { oldString: '<p>Hello</p>', newString: '<p>Hi</p>', urlPattern: 'https://example.com', isRegex: false }),
+      2: RewriteRule.fromParams(2, { oldString: '<span>World</span>', newString: '<span>Universe</span>', urlPattern: 'https://example.com', isRegex: false }),
+      3: RewriteRule.fromParams(3, { oldString: '<div>Keep</div>', newString: '<div>Changed</div>', urlPattern: 'https://other.com', isRegex: false }),
     };
     const rewriteRules = new RewriteRules(rulesObject);
     container.innerHTML = '<p>Hello</p><span>World</span><div>Keep</div>';

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/constructor/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/constructor/normal-cases.test.ts
@@ -13,8 +13,8 @@ describe('RewriteRules.constructor - 正常系', () => {
   let rulesObject: Record<string, RewriteRule>;
 
   beforeEach(() => {
-    rule1 = new RewriteRule(1, 'old1', 'new1', 'https://example.com/*', false);
-    rule2 = new RewriteRule(2, 'old2', 'new2', 'https://test.com/*', true);
+    rule1 = RewriteRule.fromParams(1, { oldString: 'old1', newString: 'new1', urlPattern: 'https://example.com/*', isRegex: false });
+    rule2 = RewriteRule.fromParams(2, { oldString: 'old2', newString: 'new2', urlPattern: 'https://test.com/*', isRegex: true });
     rulesObject = {
       1: rule1,
       2: rule2,

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/toArray/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/RewriteRules/toArray/normal-cases.test.ts
@@ -13,8 +13,8 @@ describe('RewriteRules.toArray - 正常系', () => {
   let rulesObject: Record<string, RewriteRule>;
 
   beforeEach(() => {
-    rule1 = new RewriteRule(1, 'old1', 'new1', 'https://example.com/*', false);
-    rule2 = new RewriteRule(2, 'old2', 'new2', 'https://test.com/*', true);
+    rule1 = RewriteRule.fromParams(1, { oldString: 'old1', newString: 'new1', urlPattern: 'https://example.com/*', isRegex: false });
+    rule2 = RewriteRule.fromParams(2, { oldString: 'old2', newString: 'new2', urlPattern: 'https://test.com/*', isRegex: true });
     rulesObject = {
       1: rule1,
       2: rule2,

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Tab/matchesRule/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Tab/matchesRule/normal-cases.test.ts
@@ -40,13 +40,12 @@ describe('Tab.matchesRule - 正常系', () => {
   testCases.forEach((testCase) => {
     it(testCase.description, () => {
       const tab = new Tab(1, testCase.input.tabUrl);
-      const rule = new RewriteRule(
-        1,
-        'oldText',
-        'newText',
-        testCase.input.urlPattern,
-        false
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: 'oldText',
+        newString: 'newText',
+        urlPattern: testCase.input.urlPattern,
+        isRegex: false,
+      });
 
       const result = tab.matchesRule(rule);
       expect(result).toBe(testCase.expected.result);

--- a/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Tabs/filterByRule/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/domain/value-objects/Tabs/filterByRule/normal-cases.test.ts
@@ -103,13 +103,12 @@ describe('Tabs.filterByRule - 正常系', () => {
         (tab) => new Tab(tab.tabId, tab.tabUrl)
       );
       const tabs = new Tabs(tabInstances);
-      const rule = new RewriteRule(
-        1,
-        'oldText',
-        'newText',
-        testCase.input.urlPattern,
-        false
-      );
+      const rule = RewriteRule.fromParams(1, {
+        oldString: 'oldText',
+        newString: 'newText',
+        urlPattern: testCase.input.urlPattern,
+        isRegex: false,
+      });
 
       const result = tabs.filterByRule(rule);
       const resultArray = result.toArray();

--- a/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-false.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-false.test.ts
@@ -52,12 +52,12 @@ describe('RewriteRule.matchesUrl - 正常系 (falseを返すケース)', () => {
       const oldKeyword = 'old';
       const newKeyword = 'new';
 
-      const rule = new RewriteRule(
-        ruleId,
-        oldKeyword,
-        newKeyword,
-        testCase.input.urlPattern
-      );
+      const rule = RewriteRule.fromParams(ruleId, {
+        oldString: oldKeyword,
+        newString: newKeyword,
+        urlPattern: testCase.input.urlPattern,
+        isRegex: false,
+      });
 
       // このファイルは全てfalseを期待するテスト
       const expectedResult = false;

--- a/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-true.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/matchesUrl/normal-cases-true.test.ts
@@ -60,12 +60,12 @@ describe('RewriteRule.matchesUrl - 正常系 (trueを返すケース)', () => {
       const oldKeyword = 'old';
       const newKeyword = 'new';
 
-      const rule = new RewriteRule(
-        ruleId,
-        oldKeyword,
-        newKeyword,
-        testCase.input.urlPattern
-      );
+      const rule = RewriteRule.fromParams(ruleId, {
+        oldString: oldKeyword,
+        newString: newKeyword,
+        urlPattern: testCase.input.urlPattern,
+        isRegex: false,
+      });
 
       // このファイルは全てtrueを期待するテスト
       const expectedResult = true;

--- a/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/immutability.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/immutability.test.ts
@@ -15,14 +15,13 @@ describe('RewriteRule.withActive - イミュータブル性', () => {
     const isRegex = false;
     const initialIsActive = true;
 
-    const originalRule = new RewriteRule(
-      ruleId,
+    const originalRule = RewriteRule.fromParams(ruleId, {
       oldString,
       newString,
       urlPattern,
       isRegex,
-      initialIsActive
-    );
+      isActive: initialIsActive,
+    });
 
     originalRule.withActive(false);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/normal-cases.test.ts
@@ -49,14 +49,13 @@ describe('RewriteRule.withActive - 正常系（isActive状態変更）', () => {
       const urlPattern = 'https://example.com';
       const isRegex = false;
 
-      const originalRule = new RewriteRule(
-        ruleId,
+      const originalRule = RewriteRule.fromParams(ruleId, {
         oldString,
         newString,
         urlPattern,
         isRegex,
-        testCase.input.initialIsActive
-      );
+        isActive: testCase.input.initialIsActive,
+      });
 
       const newRule = originalRule.withActive(testCase.input.newIsActive);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/property-preservation.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/enterprise-business-rules/entities/RewriteRule/withActive/property-preservation.test.ts
@@ -15,14 +15,13 @@ describe('RewriteRule.withActive - プロパティ維持', () => {
     const isRegex = true;
     const initialIsActive = true;
 
-    const originalRule = new RewriteRule(
-      ruleId,
+    const originalRule = RewriteRule.fromParams(ruleId, {
       oldString,
       newString,
       urlPattern,
       isRegex,
-      initialIsActive
-    );
+      isActive: initialIsActive,
+    });
 
     const newRule = originalRule.withActive(false);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/Abend/error-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/Abend/error-cases.test.ts
@@ -29,12 +29,12 @@ describe('DexieRewriteRuleRepository.create - 異常系', () => {
 
   it('should throw error when trying to add record with existing ID', async () => {
     // Arrange
-    const firstRule = new RewriteRule(
-      1,
-      'pattern1',
-      'replacement1',
-      ''
-    );
+    const firstRule = RewriteRule.fromParams(1, {
+      oldString: 'pattern1',
+      newString: 'replacement1',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     // 最初のルールを作成してIDを取得
     await repository.create(firstRule);

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/create/normal-cases.test.ts
@@ -32,12 +32,12 @@ describe('DexieRewriteRuleRepository.create - 正常系', () => {
     await dexieDatabase.rewriteRules.clear();
 
     repository = new DexieRewriteRuleRepository();
-    testRule = new RewriteRule(
-      1,
-      'test-pattern',
-      'test-replacement',
-      ''
-    );
+    testRule = RewriteRule.fromParams(1, {
+      oldString: 'test-pattern',
+      newString: 'test-replacement',
+      urlPattern: '',
+      isRegex: false,
+    });
   });
 
   afterEach(async () => {
@@ -46,13 +46,12 @@ describe('DexieRewriteRuleRepository.create - 正常系', () => {
 
   it('should correctly add new rule to existing rules and return Promise', async () => {
     // Arrange
-    const existingRule = new RewriteRule(
-      2,
-      'existing-pattern',
-      'existing-replacement',
-      '',
-      false
-    );
+    const existingRule = RewriteRule.fromParams(2, {
+      oldString: 'existing-pattern',
+      newString: 'existing-replacement',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     // 既存データを追加
     await repository.create(existingRule);
@@ -99,14 +98,13 @@ describe('DexieRewriteRuleRepository.create - 正常系', () => {
 
   it('should correctly create rule with all properties', async () => {
     // Arrange
-    const ruleWithAllProps = new RewriteRule(
-      3,
-      'old',
-      'new',
-      'https://test.com/*',
-      true,
-      false
-    );
+    const ruleWithAllProps = RewriteRule.fromParams(3, {
+      oldString: 'old',
+      newString: 'new',
+      urlPattern: 'https://test.com/*',
+      isRegex: true,
+      isActive: false,
+    });
 
     // Act
     await repository.create(ruleWithAllProps);

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getAll/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getAll/normal-cases.test.ts
@@ -30,20 +30,18 @@ describe('DexieRewriteRuleRepository.getAll - 正常系', () => {
 
   it('should return RewriteRules instance with stored data and return Promise', async () => {
     // Arrange
-    const rule1 = new RewriteRule(
-      1,
-      'pattern1',
-      'replacement1',
-      '',
-      false
-    );
-    const rule2 = new RewriteRule(
-      2,
-      'pattern2',
-      'replacement2',
-      '',
-      false
-    );
+    const rule1 = RewriteRule.fromParams(1, {
+      oldString: 'pattern1',
+      newString: 'replacement1',
+      urlPattern: '',
+      isRegex: false,
+    });
+    const rule2 = RewriteRule.fromParams(2, {
+      oldString: 'pattern2',
+      newString: 'replacement2',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     await repository.create(rule1);
     await repository.create(rule2);

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/error-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/error-cases.test.ts
@@ -27,13 +27,12 @@ describe('DexieRewriteRuleRepository.getById - 異常系', () => {
 
   it('should throw RewriteRuleNotFoundError when rule with specified ID does not exist', async () => {
     // Arrange
-    const rule1 = new RewriteRule(
-      1,
-      'pattern1',
-      'replacement1',
-      '',
-      false
-    );
+    const rule1 = RewriteRule.fromParams(1, {
+      oldString: 'pattern1',
+      newString: 'replacement1',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     await repository.create(rule1);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getById/normal-cases.test.ts
@@ -28,20 +28,18 @@ describe('DexieRewriteRuleRepository.getById - 正常系', () => {
 
   it('should return RewriteRule instance when rule with specified ID exists', async () => {
     // Arrange
-    const rule1 = new RewriteRule(
-      1,
-      'pattern1',
-      'replacement1',
-      '',
-      false
-    );
-    const rule2 = new RewriteRule(
-      2,
-      'pattern2',
-      'replacement2',
-      'https://example.com',
-      true
-    );
+    const rule1 = RewriteRule.fromParams(1, {
+      oldString: 'pattern1',
+      newString: 'replacement1',
+      urlPattern: '',
+      isRegex: false,
+    });
+    const rule2 = RewriteRule.fromParams(2, {
+      oldString: 'pattern2',
+      newString: 'replacement2',
+      urlPattern: 'https://example.com',
+      isRegex: true,
+    });
 
     await repository.create(rule1);
     await repository.create(rule2);
@@ -66,14 +64,13 @@ describe('DexieRewriteRuleRepository.getById - 正常系', () => {
 
   it('should correctly retrieve rule with all properties', async () => {
     // Arrange
-    const ruleWithAllProps = new RewriteRule(
-      3,
-      'old',
-      'new',
-      'https://test.com/*',
-      true,
-      false
-    );
+    const ruleWithAllProps = RewriteRule.fromParams(3, {
+      oldString: 'old',
+      newString: 'new',
+      urlPattern: 'https://test.com/*',
+      isRegex: true,
+      isActive: false,
+    });
 
     await repository.create(ruleWithAllProps);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getRulesMatchingUrl/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/getRulesMatchingUrl/normal-cases.test.ts
@@ -61,13 +61,12 @@ describe('DexieRewriteRuleRepository.getRulesMatchingUrl - 正常系', () => {
     it(description, async () => {
       // Arrange
       for (const ruleData of rulesToCreate) {
-        const rule = new RewriteRule(
-          ruleData.id,
-          ruleData.oldString,
-          ruleData.newString,
-          ruleData.urlPattern,
-          ruleData.isRegex
-        );
+        const rule = RewriteRule.fromParams(ruleData.id, {
+          oldString: ruleData.oldString,
+          newString: ruleData.newString,
+          urlPattern: ruleData.urlPattern,
+          isRegex: ruleData.isRegex,
+        });
         await repository.create(rule);
       }
 

--- a/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/update/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/frameworks-and-drivers/persistence/DexieRewriteRuleRepository/update/normal-cases.test.ts
@@ -29,20 +29,18 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
 
   it('should update existing rule with new values', async () => {
     // Arrange
-    const rule1 = new RewriteRule(
-      1,
-      'old-pattern',
-      'old-replacement',
-      '',
-      false
-    );
-    const rule2 = new RewriteRule(
-      2,
-      'pattern2',
-      'replacement2',
-      '',
-      false
-    );
+    const rule1 = RewriteRule.fromParams(1, {
+      oldString: 'old-pattern',
+      newString: 'old-replacement',
+      urlPattern: '',
+      isRegex: false,
+    });
+    const rule2 = RewriteRule.fromParams(2, {
+      oldString: 'pattern2',
+      newString: 'replacement2',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     await repository.create(rule1);
     await repository.create(rule2);
@@ -52,14 +50,13 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
     const createdRulesArray = createdRules.toArray();
     const rule1InDb = createdRulesArray.find(r => r.oldString === 'old-pattern')!;
 
-    const updatedRule = new RewriteRule(
-      rule1InDb.id,
-      'new-pattern',
-      'new-replacement',
-      'https://example.com',
-      true,
-      false
-    );
+    const updatedRule = RewriteRule.fromParams(rule1InDb.id, {
+      oldString: 'new-pattern',
+      newString: 'new-replacement',
+      urlPattern: 'https://example.com',
+      isRegex: true,
+      isActive: false,
+    });
 
     // Act
     await repository.update(updatedRule);
@@ -84,13 +81,12 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
 
   it('should update only specified properties while preserving others', async () => {
     // Arrange
-    const existingRule = new RewriteRule(
-      3,
-      'pattern',
-      'replacement',
-      'https://old.com',
-      false
-    );
+    const existingRule = RewriteRule.fromParams(3, {
+      oldString: 'pattern',
+      newString: 'replacement',
+      urlPattern: 'https://old.com',
+      isRegex: false,
+    });
 
     await repository.create(existingRule);
 
@@ -99,13 +95,12 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
     const createdRulesArray = createdRules.toArray();
     const ruleInDb = createdRulesArray[0];
 
-    const updatedRule = new RewriteRule(
-      ruleInDb.id,
-      'new-pattern',
-      'replacement',
-      'https://old.com',
-      false
-    );
+    const updatedRule = RewriteRule.fromParams(ruleInDb.id, {
+      oldString: 'new-pattern',
+      newString: 'replacement',
+      urlPattern: 'https://old.com',
+      isRegex: false,
+    });
 
     // Act
     await repository.update(updatedRule);
@@ -122,27 +117,24 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
 
   it('should preserve all rules when updating one rule', async () => {
     // Arrange
-    const rule1 = new RewriteRule(
-      4,
-      'pattern1',
-      'replacement1',
-      '',
-      false
-    );
-    const rule2 = new RewriteRule(
-      5,
-      'pattern2',
-      'replacement2',
-      '',
-      false
-    );
-    const rule3 = new RewriteRule(
-      6,
-      'pattern3',
-      'replacement3',
-      '',
-      false
-    );
+    const rule1 = RewriteRule.fromParams(4, {
+      oldString: 'pattern1',
+      newString: 'replacement1',
+      urlPattern: '',
+      isRegex: false,
+    });
+    const rule2 = RewriteRule.fromParams(5, {
+      oldString: 'pattern2',
+      newString: 'replacement2',
+      urlPattern: '',
+      isRegex: false,
+    });
+    const rule3 = RewriteRule.fromParams(6, {
+      oldString: 'pattern3',
+      newString: 'replacement3',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     await repository.create(rule1);
     await repository.create(rule2);
@@ -153,13 +145,12 @@ describe('DexieRewriteRuleRepository.update - 正常系', () => {
     const createdRulesArray = createdRules.toArray();
     const rule2InDb = createdRulesArray.find(r => r.oldString === 'pattern2')!;
 
-    const updatedRule = new RewriteRule(
-      rule2InDb.id,
-      'updated-pattern2',
-      'updated-replacement2',
-      '',
-      false
-    );
+    const updatedRule = RewriteRule.fromParams(rule2InDb.id, {
+      oldString: 'updated-pattern2',
+      newString: 'updated-replacement2',
+      urlPattern: '',
+      isRegex: false,
+    });
 
     // Act
     await repository.update(updatedRule);

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/factories/DeleteRuleControllerFactory/create/normal-cases.test.ts
@@ -46,7 +46,13 @@ describe('DeleteRuleControllerFactory.create - 正常系', () => {
 
   it('削除成功時にonSuccessコールバックが呼ばれる', async () => {
     const ruleId = 1;
-    const rule = new RewriteRule(ruleId, 'oldString', 'newString', 'https://example.com', false, true);
+    const rule = RewriteRule.fromParams(ruleId, {
+      oldString: 'oldString',
+      newString: 'newString',
+      urlPattern: 'https://example.com',
+      isRegex: false,
+      isActive: true,
+    });
     (mockRepository.getById as ReturnType<typeof vi.fn>).mockResolvedValue(rule);
     (mockRepository.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/mappers/RewriteRuleMapper/toDto/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/mappers/RewriteRuleMapper/toDto/normal-cases.test.ts
@@ -10,14 +10,13 @@ import { RewriteRuleMapper } from 'src/interface-adapters/mappers/RewriteRuleMap
 describe('RewriteRuleMapper.toDto - 正常系', () => {
   it('全プロパティを持つエンティティからDTOに変換できる', () => {
     // 静的メソッドなのでインスタンス不要
-    const entity = new RewriteRule(
-      1,
-      'old text',
-      'new text',
-      'https://example.com',
-      false,
-      true
-    );
+    const entity = RewriteRule.fromParams(1, {
+      oldString: 'old text',
+      newString: 'new text',
+      urlPattern: 'https://example.com',
+      isRegex: false,
+      isActive: true,
+    });
 
     const result = RewriteRuleMapper.toDto(entity);
 

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/ToggleRuleActivePresenter/present/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/presenters/ToggleRuleActivePresenter/present/normal-cases.test.ts
@@ -41,14 +41,13 @@ describe('ToggleRuleActivePresenter.present - 正常系（コールバック呼�
       const urlPattern = 'https://example.com';
       const isRegex = false;
 
-      const toggledRule = new RewriteRule(
-        ruleId,
+      const toggledRule = RewriteRule.fromParams(ruleId, {
         oldString,
         newString,
         urlPattern,
         isRegex,
-        testCase.input.isActive
-      );
+        isActive: testCase.input.isActive,
+      });
       const outputData = new ToggleRuleActiveOutputData(toggledRule);
       const mockUpdateRuleInView = vi.fn();
       const mockShowErrorInView = vi.fn();


### PR DESCRIPTION
## Summary
Completed the unit test for `RewriteRuleMapper.toDto` normal cases and updated the test to use the new `RewriteRule.fromParams()` factory method instead of direct constructor invocation.

## Changes
- ✅ Marked test file as complete in user story tracking document
- Updated test implementation to use `RewriteRule.fromParams()` factory method for entity creation
- Refactored entity instantiation from positional constructor arguments to named parameter object pattern for improved readability and maintainability

## Implementation Details
The test now follows the factory method pattern for creating `RewriteRule` entities, which provides:
- Better code clarity with named parameters (`oldString`, `newString`, `urlPattern`, `isRegex`, `isActive`)
- Reduced coupling to constructor signature changes
- More maintainable test code that clearly documents the entity's properties

https://claude.ai/code/session_01DPRRhcioxi15WDr5Zq1oq3