### PR TITLE
Mark Phase 2-3 tasks as completed in user story 003

### DIFF
--- a/docs/user-stories/user-story-003/README.md
+++ b/docs/user-stories/user-story-003/README.md
@@ -192,7 +192,7 @@ Phase 2以降では、以下の原則に従って実装順序を決定する:
 
 #### 結合テスト
 
-- [ ] 結合テスト戦略書に基づくテスト実装完了
+- [x] 結合テスト戦略書に基づくテスト実装完了
   - 詳細: [integration-test-strategy.md](../../design/pages/rule-list/features/delete-rule/integration-test-strategy.md)
 
 #### E2Eテスト

--- a/docs/user-stories/user-story-003/network-diagram.puml
+++ b/docs/user-stories/user-story-003/network-diagram.puml
@@ -23,8 +23,8 @@ rectangle "P2-U3\nErrorOutput\n実装+テスト" as errorImpl #lightgreen
 rectangle "P2-U4\nInteractor\n実装+テスト" as interactorImpl #lightgreen
 
 ' Phase 2: 実装 - Controller/Presenter
-rectangle "P2-C1\nController\n実装+テスト" as controllerImpl #orange
-rectangle "P2-C2\nFactory\n実装+テスト" as factoryImpl #orange
+rectangle "P2-C1\nController\n実装+テスト" as controllerImpl #lightgreen
+rectangle "P2-C2\nFactory\n実装+テスト" as factoryImpl #lightgreen
 rectangle "P2-C3\nPresenter\n実装+テスト" as presenterImpl #lightgreen
 
 ' Phase 2: 実装 - UI
@@ -33,11 +33,11 @@ rectangle "P2-UI2\nConfirmDialog\n実装+テスト" as confirmImpl #lightgreen
 rectangle "P2-UI3\nToast\n実装+テスト" as toastImpl #lightgreen
 
 ' Phase 3: 統合
-rectangle "P3-1\nRuleTableRow\nDeleteButton追加" as tableRowInteg #pink
-rectangle "P3-2\nRulesApp\n統合" as rulesAppInteg #pink
-rectangle "P3-3\nDI登録" as diReg #pink
-rectangle "P3-4\n結合テスト\n実装" as integrationTest #pink
-rectangle "P3-5\nE2Eテスト\n実装" as e2eTest #pink
+rectangle "P3-1\nRuleTableRow\nDeleteButton追加" as tableRowInteg #lightgreen
+rectangle "P3-2\nRulesApp\n統合" as rulesAppInteg #lightgreen
+rectangle "P3-3\nDI登録" as diReg #lightgreen
+rectangle "P3-4\n結合テスト\n実装" as integrationTest #lightgreen
+rectangle "P3-5\nE2Eテスト\n実装" as e2eTest #lightgreen
 
 ' 依存関係: Phase 2 内部
 requestDtoImpl --> proxyImpl
@@ -79,8 +79,6 @@ rulesAppInteg --> e2eTest
 legend right
   |= 色 |= 状態 |
   | <#lightgreen> | 完了 |
-  | <#orange> | 未完了（スケルトン） |
-  | <#pink> | Phase 3: 統合（未着手） |
 endlegend
 
 note bottom


### PR DESCRIPTION
## Summary
Update the project status documentation for user story 003 to reflect completed work on Phase 2 Controller/Factory implementation and Phase 3 integration tasks.

## Key Changes
- **Integration test status**: Marked integration test strategy implementation as complete in the checklist
- **Network diagram updates**: 
  - Changed P2-C1 (Controller) and P2-C2 (Factory) status from orange (incomplete skeleton) to lightgreen (completed)
  - Changed all Phase 3 integration tasks (P3-1 through P3-5) from pink (not started) to lightgreen (completed)
  - Removed legend entries for orange and pink status indicators as they are no longer used

## Implementation Details
The changes indicate that:
1. Controller and Factory implementation with tests have been completed
2. All Phase 3 integration work including RuleTableRow updates, RulesApp integration, DI registration, and both integration and E2E tests have been finished
3. The diagram now only uses the "completed" (lightgreen) status, simplifying the visual representation

https://claude.ai/code/session_01D6hNMtVTwdgrsbiDr34v9F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Phase 2 および Phase 3 の統合テスト実装のステータスを完了に更新しました
  * ネットワークダイアグラムでプロジェクト進捗の視覚的表示を更新し、完了部分をハイライト表示しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->