### PR TITLE
Add stylelint check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
       - name: Prepare WXT
         run: npx wxt prepare
 
-      - name: Run compile, knip, tsr, and lint checks
-        run: npm run compile && (npm run knip:all || true) && (npm run tsr:check || true) && (npm run lint || true)
+      - name: Run compile, knip, tsr, lint, and stylelint checks
+        run: npm run compile && (npm run knip:all || true) && (npm run tsr:check || true) && (npm run lint || true) && (npm run stylelint || true)
 
   e2e:
     name: E2E Tests

--- a/docs/completed/user-story-010/README.md
+++ b/docs/completed/user-story-010/README.md
@@ -32,6 +32,7 @@ stylelintを導入することで、これらの一部または全部を自動�
 - [x] pre-commit フック（lefthook）に stylelint 追加
 - [x] stylelint-rules/ ディレクトリでのルール分割
 - [x] CSS コーディング規約ドキュメントとの紐づけ
+- [x] CI（GitHub Actions）に stylelint チェック追加
 
 ### 自動検証の対応状況
 


### PR DESCRIPTION
## Summary
This PR adds stylelint validation to the GitHub Actions CI pipeline to ensure CSS code quality checks are automatically run on every commit.

## Changes
- **CI Pipeline**: Updated `.github/workflows/ci.yml` to include `npm run stylelint` check in the compile/lint verification step
- **Documentation**: Updated `docs/completed/user-story-010/README.md` to mark the CI integration task as complete

## Details
The stylelint check is added as a non-blocking step (wrapped with `|| true`) consistent with other linting tools in the pipeline (knip, tsr, lint). This ensures that:
- CSS code style violations are detected and reported in CI
- The build continues even if stylelint warnings/errors are found
- Developers are notified of style issues without blocking the pipeline

This completes the stylelint integration work that includes pre-commit hooks, rule organization, and documentation alignment.

https://claude.ai/code/session_01Rb1exfDxnmTj7cL2qJiCUL