### PR TITLE
fix: add language identifiers to code blocks in docs

### DIFF
--- a/docs/20250110-qiita.md
+++ b/docs/20250110-qiita.md
@@ -10,7 +10,7 @@
 # 最終成果物とその解説
 ## ディレクトリ構造(抜粋)
 
-```
+```text
 .
 ├── Dockerfile
 ├── docker-compose.yml
@@ -28,7 +28,7 @@
 ```
 
 ## 各ファイル
-```Dockerfile
+```dockerfile
 # 実際には wxt の初期化を行うため、作業時にいくつかのコードをコメントアウトしている
 FROM node:23.0-alpine3.19
 
@@ -44,7 +44,7 @@ RUN npm install
 
 ```
 
-```docker-compose.yml
+```yaml
 services:
   frontend:
     image: frontend-image
@@ -58,7 +58,7 @@ services:
     network_mode: host
 ```
 
-```typescript:wxt.config.ts
+```typescript
 import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
@@ -98,18 +98,18 @@ export default defineConfig({
 
 ## 初期ディレクトリ、ファイル構成
 プロジェクトルートにフォルダを作成
-```bash:WSL on win11
+```bash
 mkdir host-frontend-root
 ```
 
 プロジェクトルートに Dockerfile、docker-compose.yml を作成
-```bash:WSL on win11
+```bash
 echo "FROM node:23.0-alpine3.19" > Dockerfile
 echo "services:" > docker-compose.yml
 ```
 
 この時点のディレクトリ構造は下記の通り
-```bash:WSL on win11
+```bash
 tree -I .
 .
 ├── Dockerfile
@@ -123,7 +123,7 @@ tree -I .
 
 ## 初期コンテナ作成
 あとで使う箇所をコメントアウトしておく
-```Dockerfile:Dockerfile
+```dockerfile
 FROM node:23.0-alpine3.19
 
 WORKDIR /opt/frontend-container-app-root/frontend-src-root
@@ -137,7 +137,7 @@ RUN apk add --no-cache \
 # RUN npm install
 ```
 
-```docker-compose.yml
+```yaml
 services:
   frontend:
     image: frontend-image
@@ -152,25 +152,25 @@ services:
 ```
 
 コンテナを起動する
-```bash:WSL on win11
+```bash
 docker compose build --no-cache && docker compose up -d && docker compose ps
 ```
 
 ## wxtを使ってプロジェクトを作成
 VS Code のリモートエクスプローラーで起動したコンテナに接続する
 
-```bash:container
+```bash
 pwd
 /opt/frontend-container-app-root
 ```
 
 wxt を使ってプロジェクトを作成する
-```bash:container
+```bash
 npx wxt@latest init frontend-src-root
 ```
 を実行。今回はreact、npmを選んでいるが、目的に応じて変えて良い
 
-```bash:container
+```text
 npx wxt@latest init frontend-src-root
 WXT 0.19.23
 ℹ Initalizing new project
@@ -186,7 +186,7 @@ Next steps:
 ```
 
 ログが示してくれた通りコマンドを実行
-```bash:container
+```bash
 cd frontend-src-root
 npm install
 
@@ -204,7 +204,7 @@ added 546 packages in 8m
 ```
 
 wxt.config.ts を編集
-```typescript:wxt.config.ts
+```typescript
 import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
@@ -234,7 +234,7 @@ export default defineConfig({
 });
 ```
 
-```bash:container
+```text
 /opt/frontend-container-app-root/frontend-src-root # npm run dev
 
 > wxt-react-starter@0.0.0 dev
@@ -261,13 +261,13 @@ WXT 0.19.23
 ```
 
 ホスト側でもファイル修正できるように権限を修正
-```bash:WSL on win11
+```bash
 sudo chown -R (wslユーザー名):(wslユーザー名) frontend-src-root/
 ```
 
 ## chrome-mv3 を手動で読み込む
 wxt.config.ts で
-```typescript:wxt.config.ts
+```typescript
   runner: {
     disabled: true,
   },
@@ -284,7 +284,7 @@ chrome://extensions/ ＞ パッケージ化されていない拡張機能を読�
 リモートエクスプローラーを閉じ、ここまでを一旦コミットする
 
 ## Dockerfile による永続化
-```Dockerfile
+```dockerfile
 FROM node:23.0-alpine3.19
 
 WORKDIR /opt/frontend-container-app-root/frontend-src-root
@@ -299,12 +299,12 @@ RUN npm install
 ```
 
 再ビルド
-```bash:WSL on win11
+```bash
 docker compose build --no-cache && docker compose up -d && docker compose ps
 ```
 
 docker コマンドでコンテナに接続して、npm run dev を実行
-```bash:WSL on win11
+```bash
 docker compose exec frontend npm run dev
 ```
 
@@ -323,7 +323,7 @@ docker compose exec frontend npm run dev
 https://wxt.dev/guide/essentials/config/vite.html#change-vite-config
 によれば、通常vite.config.tsのdefineConfigに記述する内容を、wxt.config.tsに記述することで、Viteの設定を変更できる。
 
-```
+```typescript
 // wxt.config.ts
 import { defineConfig } from 'wxt';
 
@@ -345,7 +345,7 @@ export default defineConfig({
 
 ビルド速度向上のため、ホスト側からのソースコードコピー前にnpm installを実行したい。
 
-```
+```dockerfile
 # 1. package.json と lockファイルのみコピー
 COPY ./host-frontend-root/frontend-src-root/package*.json ./
 
@@ -356,18 +356,18 @@ RUN npm install
 COPY ./host-frontend-root/frontend-src-root ./
 ```
 しかし、wxtの場合、npm installを実行すると、`npx wxt@latest init`コマンド実行時にデフォルトで用意される
-```json:package.json
+```json
   "postinstall": "wxt prepare"
 ```
 が実行される。これにより、
-```
+```text
 ERROR  No entrypoints found in /opt/frontend-container-app-root/frontend-src-root/entrypoints
 ```
 というエラーが発生するため、 `RUN npm install` 前にソースコードが存在している必要がある。
 
 回避するには`package.json`から`postinstall`を削除し、以下のように書き換える方法がある。
 
-```
+```dockerfile
 # 1. package.json と lockファイルのみコピー
 COPY ./host-frontend-root/frontend-src-root/package*.json ./
 
@@ -385,14 +385,14 @@ RUN npx wxt prepare
 
 ## wxt.config.tsのrunner: { disabled: true } について
 wxt.config.ts で
-```typescript:wxt.config.ts
+```typescript
   runner: {
     disabled: true,
   },
 ```
 と設定しているが、本来はfalseやオプション削除が望ましい。しかし、これを削除すると下記エラーが発生する。
 
-```
+```text
 ✖ Command failed after 34.1 s
 
  ERROR  connect ECONNREFUSED 127.0.0.1:32885

--- a/docs/adr/001-clean-architecture-with-presenter-pattern.md
+++ b/docs/adr/001-clean-architecture-with-presenter-pattern.md
@@ -22,7 +22,7 @@
 
 ### 1. ディレクトリ構造: Clean Architecture 4層の正式名称を使用
 
-```
+```text
 src/
 ├── enterprise-business-rules/   ← 第1層: Enterprise Business Rules (Entities)
 ├── application-business-rules/  ← 第2層: Application Business Rules (Use Cases)
@@ -38,7 +38,7 @@ src/
 - Controller → Input Port ← Interactor (implements)
 - Interactor → Output Port ← Presenter (implements)
 
-```
+```text
 【制御の流れ（実線矢印）】
 
 ┌──────────┐    ┌──────────────┐    ┌──────────────┐    ┌──────────────┐    ┌───────────┐
@@ -88,7 +88,7 @@ src/
 
 ### 4. 詳細ディレクトリ構造
 
-```
+```text
 src/
 ├── enterprise-business-rules/                   ← 第1層: Enterprise Business Rules
 │   ├── entities/                               ← Entity
@@ -152,7 +152,7 @@ src/
 
 ### 5. 依存関係ルール
 
-```
+```text
 内側（安定）                                            外側（不安定）
 ───────────────────────────────────────────────────────────────────────→
 
@@ -182,7 +182,7 @@ src/
 
 #### 実装パターン
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │ enterprise-business-rules (第1層)                                │
 │                                                                 │
@@ -216,7 +216,7 @@ src/
 
 #### 制御の流れ
 
-```
+```text
 【正常系】
 View → Controller → Interactor → Presenter.present(OutputData) → View
 

--- a/docs/adr/002-messaging-with-webext-core.md
+++ b/docs/adr/002-messaging-with-webext-core.md
@@ -64,7 +64,7 @@ Mapper は変換だけでなく、MessagingService への呼び出しも担当�
 
 Clean Architecture の依存ルールを守るため、Mapper（interface-adapters 層）が MessagingService（frameworks-and-drivers 層）を直接参照することを避ける。
 
-```
+```text
 [interface-adapters]
   IRewriteRuleMessagingPort (interface)
   RewriteRuleMapper → uses → IRewriteRuleMessagingPort
@@ -86,7 +86,7 @@ Clean Architecture の依存ルールを守るため、Mapper（interface-adapte
 
 `@webext-core/proxy-service` を使用する場合、Background Script と Content Script の両方で同じモジュールを import する必要がある。しかし、proxy-service 実装が DI コンテナ（container.ts）を静的 import すると、Content Script でモジュールをロードした際に Background 専用の依存関係も一緒にロードされ、問題が発生する。
 
-```
+```text
 # 問題のあるパターン
 RewriteRuleProxyService.ts
   └── import { container } from 'container.ts'  ← 静的 import

--- a/docs/adr/004-tabs-collection-layer-placement.md
+++ b/docs/adr/004-tabs-collection-layer-placement.md
@@ -49,7 +49,7 @@ ADR-001「ドメインロジックの配置原則」に従う:
 
 ### 依存関係
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │ enterprise-business-rules (第1層)                       │
 │   RewriteRule.matchesUrl(url: string): boolean         │

--- a/docs/adr/005-factory-pattern-for-react-callback-injection.md
+++ b/docs/adr/005-factory-pattern-for-react-callback-injection.md
@@ -32,7 +32,7 @@ Clean Architecture + Presenterパターン（ADR-001）では、Presenterが処�
 1. **起動時（DIコンテナ）**: Repository, Gateway など技術的依存をFactoryに注入
 2. **レンダリング時（Factory.create）**: Reactコールバック（成功/エラー時の状態更新関数）をPresenterに注入
 
-```
+```text
 DIコンテナ（起動時）          Reactコンポーネント（レンダリング時）
        │                              │
        ▼                              ▼

--- a/docs/adr/008-ui-component-directory-migration.md
+++ b/docs/adr/008-ui-component-directory-migration.md
@@ -23,7 +23,7 @@ UIコンポーネントの配置を段階的に移行する:
 
 新規作成するUIコンポーネントは、すべて `src/frameworks-and-drivers/ui/components/` に配置する。
 
-```
+```text
 src/frameworks-and-drivers/ui/components/
 ├── atoms/
 │   ├── DeleteButton/

--- a/docs/coding-standards/tests/unit/common-rule/basic-rule.md
+++ b/docs/coding-standards/tests/unit/common-rule/basic-rule.md
@@ -27,7 +27,7 @@
 3. **命名規則**: モックファクトリは `createMock[ClassName].ts` の形式で命名
 
 **モックファクトリの配置例**:
-```
+```text
 tests/unit/[layer]/[category]/[ServiceName]/
 ├── [methodName]/
 │   └── normal-cases.test.ts
@@ -78,7 +78,7 @@ Clean Architectureの各層に特化したテスト規約です。
 ### テストファイル構造とディレクトリ構成
 
 #### ディレクトリ構造の原則
-```
+```text
 tests/unit/[layer]/[category]/[service-name]/
 ├── [method-name]/
 │   ├── normal-cases.test.ts         # 正常系テスト


### PR DESCRIPTION
## Summary
- Fix all 41 MD040 markdownlint violations in `docs/` directory
- Add appropriate language identifiers to fenced code blocks
- Standardize non-standard language identifiers

## Files Fixed (7 files, 41 total fixes)
- `docs/20250110-qiita.md`: 28 fixes
- `docs/adr/*.md`: 11 fixes  
- `docs/coding-standards/*.md`: 2 fixes

## Language Standardization
- `bash` (was `bash:WSL`, `bash:container`)
- `dockerfile` (was `Dockerfile`)  
- `yaml` (was `docker-compose.yml`)
- `json` (was `json:package.json`)
- `text` for diagrams and directory structures
- `typescript` for TypeScript code

## Test Plan
- [x] Run `make lintmd` - all checks pass (0 errors)
- [x] Verify all code blocks have appropriate language identifiers
- [x] Confirm syntax highlighting works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * ドキュメント内のコードブロックのフォーマットを改善しました。マークダウンファイル内の複数のコードフェンスを明示的な言語指定に更新し、可読性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->