### PR TITLE
Fix markdown linting for cline-instructions blocks

### DIFF
--- a/.clinerules/02-workflow-automation/01-issue-launches/workflow-ccw-session-start.md
+++ b/.clinerules/02-workflow-automation/01-issue-launches/workflow-ccw-session-start.md
@@ -1,5 +1,5 @@
 workflow-ccw-session-start branch-suffix=
-```cline-instructions
+````cline-instructions
 ## Claude Code Web セッション開始ワークフロー
 
 このワークフローは、Claude Code Webで新しいセッションを開始する際に実行します。
@@ -61,4 +61,4 @@ https://github.com/akAredminEogre/frog-frame-front/compare/develop...<ブラン�
 - このワークフローはClaude Code Web専用です
 - ターミナル版Claude Codeでは `/workflow-create-branch` を使用してください
 - ブランチ名は必ず `claude/` で始めてください（Claude Code Webの制約）
-```
+````

--- a/.clinerules/02-workflow-automation/01-issue-launches/workflow-get-new-branch-number.md
+++ b/.clinerules/02-workflow-automation/01-issue-launches/workflow-get-new-branch-number.md
@@ -1,5 +1,5 @@
 workflow-get-new-branch-number
-```cline-instructions
+````cline-instructions
 issue番号の採番ロジック：
 
 以下のスクリプトを実行して新しいissue番号を取得する：
@@ -20,4 +20,4 @@ nnn=$(scripts/.clinerules/get-new-issue-number.sh)
 出力形式：
 - 3桁の番号を標準出力に出力（例: "087", "001", "123"）
 - 変数 `nnn` に格納して後続処理で使用する
-```
+````

--- a/.clinerules/02-workflow-automation/02-daily-scrum-starts/workflow-create-daily-scrum.md
+++ b/.clinerules/02-workflow-automation/02-daily-scrum-starts/workflow-create-daily-scrum.md
@@ -1,6 +1,6 @@
 frog-frame-front/.clinerules/02-workflow-automation/02-daily-scrum-starts/workflow-create-daily-scrum.md
 
-```cline-instructions
+````cline-instructions
 nnn=$(scripts/.clinerules/get-issue-number.sh)
 kk=(docs/issue-nnn/daily-scrum-mm(mは任意の数字)のディレクトリナンバーの最大数+1)
 スクラムkk回目の作業を計画を立ててもらいます。
@@ -20,4 +20,4 @@ mkdir -p docs/issue-nnn/daily-scrum-kk/
     - の手順を **指示を待たずに自動的に** 実行する
   - ## 相談事項セクションに記入がある場合
   　- チャットスレッドに記入がある旨表示し、本ワークフローを終了する
-```
+````

--- a/.clinerules/02-workflow-automation/03-daily-scrum-finishes/01-create-daily-scrum-doc-after-coding.md
+++ b/.clinerules/02-workflow-automation/03-daily-scrum-finishes/01-create-daily-scrum-doc-after-coding.md
@@ -1,6 +1,6 @@
 workflow-create-daily-scrum-doc-after-coding
 
-```cline-instructions
+````cline-instructions
 nnn=$(scripts/.clinerules/get-issue-number.sh)
 kk=(docs/issue-nnn/daily-scrum-mm(mは任意の数字)のディレクトリナンバーの最大数+1)
 作業ありがとうございました。今回の作業を
@@ -16,4 +16,4 @@ cp docs/issue-000/daily-scrum-00/DAILY_SCRUM-.md docs/issue-nnn/daily-scrum-kk/D
 
 - 今回の作業内容、チャットスレッドの内容に基づき、frog-frame-front/docs/issue-000/daily-scrum-00/DAILY_SCRUM-.mdのフォーマットに従って、先ほどコピーしたdocs/issue-nnn/daily-scrum-kk/DAILY_SCRUM-kk.mdに記入してください。
 
-```
+````

--- a/.clinerules/02-workflow-automation/03-daily-scrum-finishes/workflow-after-coding-record-progress.md
+++ b/.clinerules/02-workflow-automation/03-daily-scrum-finishes/workflow-after-coding-record-progress.md
@@ -4,7 +4,7 @@ cline-instructionsの手順をチャットスレッドに表示してから実�
 その中で別のworkflowに従うと指示されてる場合は、その手順も検索・確認して再帰的にチャットスレッドに表示してください
 手順全体表示はあなたの確認のために行うものなので、開発者の指示・操作を待たずその表示した手順に従って実行してください
 
-```cline-instructions
+````cline-instructions
 nnn=$(scripts/.clinerules/get-issue-number.sh)
 kk=(docs/issue-nnn/daily-scrum-mm(mは任意の数字)のディレクトリナンバーの最大数+1)
 作業ありがとうございました。今回の作業を
@@ -23,4 +23,4 @@ cp docs/issue-000/daily-scrum-00/DAILY_SCRUM-.md docs/issue-nnn/daily-scrum-kk/D
 の出力結果に基づき、
 workflow-record-progress に従って、docs/issue-nnn/daily-scrum-kk/PROGRESS-kk-ii.mdを作成してください。
 
-```
+````

--- a/.clinerules/02-workflow-automation/04-pull-request/workflow-ccw-merge-pull-request.md
+++ b/.clinerules/02-workflow-automation/04-pull-request/workflow-ccw-merge-pull-request.md
@@ -3,7 +3,7 @@ workflow-ccw-merge-pull-request
 Claude Code Web版のプルリクエストマージワークフローです。
 ghコマンドが使用できないため、一部の作業は手動で行う必要があります。
 
-```cline-instructions
+````cline-instructions
 ## Claude Code Web PRマージワークフロー
 
 ### 1. Issue番号の取得
@@ -67,4 +67,4 @@ https://github.com/akAredminEogre/frog-frame-front/pulls
 ### 注意
 - ターミナル版Claude Codeでは `/workflow-merge-pull-request` を使用してください
 ```
-```
+````

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -23,7 +23,8 @@
       "markdown",
       "text",
       "dockerfile",
-      "plaintext"
+      "plaintext",
+      "cline-instructions"
     ],
     "language_only": false
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,12 @@ make sortimports  # Sort imports in all files
 make lintmd       # Run markdownlint (targets: docs/, docs-rules/, .claude/, .clinerules/, *.md; runs on host)
 make lintmdfix    # Run markdownlint with --fix (targets: docs/, docs-rules/, .claude/, .clinerules/, *.md; runs on host)
 make checklinks   # Check for broken links (targets: docs/, docs-rules/, .claude/, .clinerules/; external URLs excluded; runs on host)
+
+# Markdown linting (npm scripts - alternative to make commands, run from host-frontend-root/frontend-src-root/)
+npm run lint:md       # Run markdownlint (same targets as make lintmd; uses .markdownlint-cli2.jsonc config)
+npm run lint:md:fix   # Run markdownlint with --fix (same targets as make lintmdfix)
+npm run check:links   # Check for broken links (same targets as make checklinks; uses .markdown-link-check.json config)
+
 docker compose exec frontend npm run compile        # TypeScript compilation check
 docker compose exec frontend npm run lint           # Run ESLint
 docker compose exec frontend npm run lint:fix       # Auto-fix ESLint issues
@@ -481,7 +487,7 @@ docs/
 
 このワークフローは以下を行います：
 - **pre-commitフックのセットアップ**（ESLint + import sorting）
-- Issue番号の採番
+- Issue番号の採番（内部的に `workflow-get-new-branch-number` を使用）
 - `docs/issue-nnn/` ディレクトリ作成
 - ブランチ作成（既にブランチが指定されている場合はスキップ）
 - PR作成リンクの表示

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,9 @@ make testall      # Both unit and E2E tests
 # Code quality checks
 make check        # Run compile, knip, tsr, and lint checks
 make sortimports  # Sort imports in all files
-make lintmd       # Run markdownlint (targets: docs/, docs-rules/, .claude/, *.md; runs on host)
-make lintmdfix    # Run markdownlint with --fix (targets: docs/, docs-rules/, .claude/, *.md; runs on host)
-make checklinks   # Check for broken links (targets: docs/, docs-rules/, .claude/; external URLs excluded; runs on host)
+make lintmd       # Run markdownlint (targets: docs/, docs-rules/, .claude/, .clinerules/, *.md; runs on host)
+make lintmdfix    # Run markdownlint with --fix (targets: docs/, docs-rules/, .claude/, .clinerules/, *.md; runs on host)
+make checklinks   # Check for broken links (targets: docs/, docs-rules/, .claude/, .clinerules/; external URLs excluded; runs on host)
 docker compose exec frontend npm run compile        # TypeScript compilation check
 docker compose exec frontend npm run lint           # Run ESLint
 docker compose exec frontend npm run lint:fix       # Auto-fix ESLint issues

--- a/docs/coding-standards/make/entire-standards.md
+++ b/docs/coding-standards/make/entire-standards.md
@@ -9,6 +9,11 @@
    - `make/help/main.mk` の該当カテゴリ（`make help` で表示される内容）
 4. **npm scriptsを実行する場合**: `docker compose exec frontend npm run <script>` 形式を使用すること。直接 `npx` や `npm run` を使用しない（ローカル環境でのパッケージインストール不要、一貫性の維持）
    - **例外**: `docs/`ディレクトリにアクセスが必要なコマンド（例: `lintmd`）は、Dockerコンテナ内に`docs/`がマウントされていないため、ホストから直接実行する
+5. **Makefileターゲットと対応するnpm scriptsを同期する場合**: 同じ機能を提供するMakefileターゲットとnpm scriptsが存在する場合（例: `make lintmd` と `npm run lint:md`、`make checklinks` と `npm run check:links`）、以下を必ず確認すること
+   - ターゲットディレクトリ（対象ファイル範囲）が一致していること
+   - 設定ファイルの参照（例: `-c .markdown-link-check.json`）が一致していること
+   - コマンドオプション（例: `-q`、`--fix`）が一致していること
+   - 変更時は両方を同時に更新し、CLAUDE.mdのドキュメントも更新すること
 
 ## オブジェクト指向ルール（ThoughtWorksアンソロジー）
 

--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -50,7 +50,7 @@
     "stylelint:fix": "stylelint 'src/**/*.css' --fix",
     "lint:md": "cd ../.. && npx markdownlint-cli2 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'",
     "lint:md:fix": "cd ../.. && npx markdownlint-cli2 --fix 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'",
-    "check:links": "cd ../.. && find docs docs-rules .claude .clinerules -name '*.md' -not -path 'docs/user-stories/completed/*' -not -path 'docs/issues/completed/*' -print0 | xargs -0 -P 4 -n 10 npx markdown-link-check -q"
+    "check:links": "cd ../.. && find docs docs-rules .claude .clinerules -name '*.md' -not -path 'docs/user-stories/completed/*' -not -path 'docs/issues/completed/*' -print0 | xargs -0 -P 4 -n 10 npx markdown-link-check -q -c .markdown-link-check.json"
   },
   "dependencies": {
     "@react-aria/dialog": "^3.5.32",

--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -48,9 +48,9 @@
     "sort:imports": "eslint . --ext .ts,.tsx,.js,.jsx --fix --rule 'simple-import-sort/imports: error' --rule 'simple-import-sort/exports: error'",
     "stylelint": "stylelint 'src/**/*.css'",
     "stylelint:fix": "stylelint 'src/**/*.css' --fix",
-    "lint:md": "cd ../.. && npx markdownlint-cli2 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '*.md'",
-    "lint:md:fix": "cd ../.. && npx markdownlint-cli2 --fix 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '*.md'",
-    "check:links": "cd ../.. && find docs docs-rules .claude -name '*.md' -not -path 'docs/user-stories/completed/*' -not -path 'docs/issues/completed/*' -print0 | xargs -0 -P 4 -n 10 npx markdown-link-check -q"
+    "lint:md": "cd ../.. && npx markdownlint-cli2 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'",
+    "lint:md:fix": "cd ../.. && npx markdownlint-cli2 --fix 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'",
+    "check:links": "cd ../.. && find docs docs-rules .claude .clinerules -name '*.md' -not -path 'docs/user-stories/completed/*' -not -path 'docs/issues/completed/*' -print0 | xargs -0 -P 4 -n 10 npx markdown-link-check -q"
   },
   "dependencies": {
     "@react-aria/dialog": "^3.5.32",

--- a/make/test/main.mk
+++ b/make/test/main.mk
@@ -31,15 +31,15 @@ sortimports:
 
 lintmd:
 	@echo "Running markdownlint..."
-	@npx markdownlint-cli2 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '*.md'
+	@npx markdownlint-cli2 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'
 
 lintmdfix:
 	@echo "Running markdownlint with auto-fix..."
-	@npx markdownlint-cli2 --fix 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '*.md'
+	@npx markdownlint-cli2 --fix 'docs/**/*.md' 'docs-rules/**/*.md' '.claude/**/*.md' '.clinerules/**/*.md' '*.md'
 
 checklinks:
 	@echo "Checking markdown links..."
-	@find docs docs-rules .claude -name '*.md' \
+	@find docs docs-rules .claude .clinerules -name '*.md' \
 		-not -path 'docs/user-stories/completed/*' \
 		-not -path 'docs/issues/completed/*' \
 		-print0 | xargs -0 -P 4 -n 10 npx markdown-link-check -q -c .markdown-link-check.json


### PR DESCRIPTION
## Summary
This PR fixes markdown linting issues in the `.clinerules/` directory by updating code fence markers and adding the directory to linting configurations.

## Key Changes

- **Code fence markers**: Updated all cline-instructions code blocks from triple backticks (` ``` `) to quadruple backticks (` ```` `) in `.clinerules/` workflow files
  - This prevents markdown linters from treating the content as code blocks and allows proper validation of the instructions within
  
- **Linting configuration**: Added `cline-instructions` as a recognized language in `.markdownlint.jsonc`
  - Ensures the linter properly handles these custom instruction blocks

- **Build scripts and documentation**: Updated all references to include `.clinerules/` directory in:
  - `CLAUDE.md` - Updated make command documentation
  - `package.json` - Updated npm script targets for `lint:md`, `lint:md:fix`, and `check:links`
  - `make/test/main.mk` - Updated makefile targets for linting and link checking

## Files Modified
- 4 workflow files in `.clinerules/02-workflow-automation/`
- `.markdownlint.jsonc` - Added language support
- `CLAUDE.md` - Updated documentation
- `host-frontend-root/frontend-src-root/package.json` - Updated npm scripts
- `make/test/main.mk` - Updated makefile rules

## Impact
- `.clinerules/` markdown files are now properly linted alongside other documentation
- Workflow instruction blocks are correctly formatted and validated
- Consistent linting coverage across all markdown documentation in the project

https://claude.ai/code/session_01Si6pr1PcCeSC1Lf1WK5DHi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Markdownリンティングおよびリンクチェックの対象範囲を拡張しました。
  * コードブロック形式の設定を更新し、追加の構文をサポートするようになりました。
  * ドキュメント関連の構成ファイルを更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->