### PR TITLE
Add test strategy and unit tests for ExportRulesJsonController

### DIFF
--- a/docs/design/src/interface-adapters/controllers/ExportRulesJsonController/exportRulesJson.md
+++ b/docs/design/src/interface-adapters/controllers/ExportRulesJsonController/exportRulesJson.md
@@ -1,0 +1,69 @@
+# ExportRulesJsonController.exportRulesJson() テスト戦略
+
+## 目的
+
+ルールJSONエクスポートのリクエストを受け取り、ExportRulesJsonInputDataを生成してUseCaseを呼び出す。
+Controllerの責務は入力変換とUseCase呼び出しのみで、ビジネスロジックは含まない。
+
+## テスト分類
+
+### 1. 正常系（UseCase呼び出し）
+
+UseCaseのexecuteメソッドが正しく呼び出されることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| 基本パターン | exportRulesJson()でUseCaseのexecuteが1回呼び出される | UseCase委譲の確認 |
+
+**対応テスト**: `normal-cases.test.ts`
+
+### 2. InputData生成
+
+UseCaseに渡されるInputDataが正しく生成されていることを確認。
+
+| 分類 | テストケース | 根拠 |
+|------|-------------|------|
+| InputData型 | ExportRulesJsonInputDataインスタンスが渡される | 入力変換の正確性 |
+
+**対応テスト**: `normal-cases.test.ts`（上記と同一テスト内で検証）
+
+## 網羅性チェック
+
+- [x] UseCaseのexecuteが呼び出されること
+- [x] ExportRulesJsonInputDataが渡されること
+- [ ] 異常系（UseCase側のエラー） → 不要（Controllerはエラーをキャッチせず呼び出し元に伝播）
+
+### 異常系テストが不要な理由
+
+ControllerはUseCase呼び出しのみを担当し、エラーハンドリングの責務を持たない：
+
+1. **責務の分離**: Controllerは入力変換のみ、ビジネスロジックエラーはInteractor層
+2. **エラー伝播**: UseCaseからのエラーは呼び出し元（View層）に伝播してUIで処理
+
+### パラメータバリエーションが不要な理由
+
+ExportRulesJsonController.exportRulesJson()は引数を取らない（全ルールエクスポートのため）。
+DeleteRuleController.deleteRule(ruleId)のような入力値のバリエーションテストは不要。
+
+## テストファイル構成
+
+```text
+tests/unit/interface-adapters/controllers/ExportRulesJsonController/exportRulesJson/
+└── normal-cases.test.ts       # UseCase呼び出し確認（1ケース）
+```
+
+## モック戦略
+
+UseCaseをモック化し、Controllerの責務（UseCase呼び出し）のみをテストする。
+
+### 使用するモック
+
+> **注意**: 新規モック作成前に既存モックを確認すること。詳細は [mock-file-placement.md](/docs/coding-standards/tests/common-rule/mock-file-placement.md) を参照。
+
+| 依存関係 | モック理由 | モック対応 |
+| -------- | ---------- | ---------- |
+| IExportRulesJsonUseCase | UseCase呼び出しの検証 | 新規作成（`tests/unit/application-business-rules/ports/input/IExportRulesJsonUseCase/mocks/`） |
+
+### テストデータ
+
+ExportRulesJsonInputDataは実インスタンスを使用（Controllerが生成するため、型の検証に使用）。

--- a/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/ports/input/IExportRulesJsonUseCase/mocks/createMockExportRulesJsonUseCase.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/application-business-rules/ports/input/IExportRulesJsonUseCase/mocks/createMockExportRulesJsonUseCase.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest';
+
+import { IExportRulesJsonUseCase } from 'src/application-business-rules/ports/input/IExportRulesJsonUseCase';
+
+/**
+ * IExportRulesJsonUseCaseのモックオブジェクトを生成する
+ * @returns IExportRulesJsonUseCase型のモックオブジェクト
+ */
+export const createMockExportRulesJsonUseCase =
+  (): IExportRulesJsonUseCase => {
+    return {
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+  };

--- a/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/ExportRulesJsonController/exportRulesJson/normal-cases.test.ts
+++ b/host-frontend-root/frontend-src-root/tests/unit/interface-adapters/controllers/ExportRulesJsonController/exportRulesJson/normal-cases.test.ts
@@ -1,0 +1,34 @@
+/**
+ * ExportRulesJsonController.exportRulesJson - 正常系テスト
+ * 1. exportRulesJson()でUseCaseのexecuteが1回呼び出される
+ */
+import { createMockExportRulesJsonUseCase } from 'tests/unit/application-business-rules/ports/input/IExportRulesJsonUseCase/mocks/createMockExportRulesJsonUseCase';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExportRulesJsonInputData } from 'src/application-business-rules/dto/input/ExportRulesJsonInputData';
+import { IExportRulesJsonUseCase } from 'src/application-business-rules/ports/input/IExportRulesJsonUseCase';
+import { ExportRulesJsonController } from 'src/interface-adapters/controllers/ExportRulesJsonController';
+
+describe('ExportRulesJsonController.exportRulesJson - 正常系', () => {
+  let mockUseCase: IExportRulesJsonUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCase = createMockExportRulesJsonUseCase();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('exportRulesJson()でUseCaseのexecuteが1回呼び出される', async () => {
+    const controller = new ExportRulesJsonController(mockUseCase);
+
+    await controller.exportRulesJson();
+
+    expect(mockUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(mockUseCase.execute).toHaveBeenCalledWith(
+      expect.any(ExportRulesJsonInputData)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive test documentation and unit tests for the `ExportRulesJsonController.exportRulesJson()` method, following the established testing patterns and clean architecture principles.

## Key Changes

- **Test Strategy Documentation** (`exportRulesJson.md`):
  - Defined testing scope: verification that UseCase is correctly invoked with proper InputData
  - Documented why abnormal cases and parameter variations are not needed
  - Explained the rationale for error handling responsibility separation
  - Specified mock strategy and test file organization

- **Unit Test Implementation** (`normal-cases.test.ts`):
  - Single test case verifying UseCase `execute()` is called exactly once
  - Validates that `ExportRulesJsonInputData` instance is passed to UseCase
  - Uses mocked UseCase to isolate Controller behavior

- **Mock Factory** (`createMockExportRulesJsonUseCase.ts`):
  - New mock factory for `IExportRulesJsonUseCase`
  - Returns mock with `execute` method that resolves to undefined
  - Follows established mock placement conventions

## Notable Implementation Details

- Controller testing focuses solely on input transformation and UseCase delegation
- No error handling tests as Controller delegates errors to calling layer (View)
- No parameter variation tests as `exportRulesJson()` takes no arguments
- Mock strategy isolates Controller from UseCase implementation details
- Aligns with clean architecture separation of concerns

https://claude.ai/code/session_01KdKyw3p21zwEc6Vb3DDKg4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * テスト戦略に関する新しいドキュメンテーションを追加しました。

* **Tests**
  * ユニットテストとテスト用のモック機能を追加し、品質保証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->