### PR TITLE
fix: vitest maxForks=2制限追加（WSL2 OOM対策）

### DIFF
--- a/host-frontend-root/frontend-src-root/vitest.config.ts
+++ b/host-frontend-root/frontend-src-root/vitest.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vitest/config';
 import { WxtVitest } from 'wxt/testing';
 import path from 'path';
 
-// WSL2環境の検出（WSL_DISTRO_NAMEはWSL2でのみ設定される）
-const isWSL2 =
+// WSL環境の検出（CI環境を除外。WSL_DISTRO_NAMEはWSL/WSL2で設定される）
+const isWSL =
   process.env.CI === undefined &&
   process.env.WSL_DISTRO_NAME !== undefined;
 
@@ -24,11 +24,14 @@ export default defineConfig({
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     // Playwrightテストファイルとnode_modulesを明示的に除外
     exclude: ['**/*.spec.ts', 'e2e/**/*', 'node_modules/**/*'],
-    pool: 'forks',
-    poolOptions: {
-      forks: {
-        maxForks: isWSL2 ? 2 : undefined,
+    // WSL環境のみforks poolを使用してmaxForks=2に制限（CI・その他環境はデフォルト）
+    ...(isWSL ? {
+      pool: 'forks',
+      poolOptions: {
+        forks: {
+          maxForks: 2,
+        },
       },
-    }
+    } : {}),
   },
 });

--- a/host-frontend-root/frontend-src-root/vitest.config.ts
+++ b/host-frontend-root/frontend-src-root/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     // tests/ ディレクトリのVitestテストファイル（.ts, .tsx形式）を対象とする
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     // Playwrightテストファイルとnode_modulesを明示的に除外
-    exclude: ['**/*.spec.ts', 'e2e/**/*', 'node_modules/**/*']
+    exclude: ['**/*.spec.ts', 'e2e/**/*', 'node_modules/**/*'],
+    poolOptions: {
+      forks: {
+        maxForks: 2
+      }
+    }
   },
 });

--- a/host-frontend-root/frontend-src-root/vitest.config.ts
+++ b/host-frontend-root/frontend-src-root/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import { WxtVitest } from 'wxt/testing';
 import path from 'path';
 
+// WSL2環境の検出（WSL_DISTRO_NAMEはWSL2でのみ設定される）
+const isWSL2 = process.env.WSL_DISTRO_NAME !== undefined;
+
 export default defineConfig({
   plugins: [WxtVitest()],
   resolve: {
@@ -19,10 +22,11 @@ export default defineConfig({
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     // Playwrightテストファイルとnode_modulesを明示的に除外
     exclude: ['**/*.spec.ts', 'e2e/**/*', 'node_modules/**/*'],
+    pool: 'forks',
     poolOptions: {
       forks: {
-        maxForks: 2
-      }
+        maxForks: isWSL2 ? 2 : undefined,
+      },
     }
   },
 });

--- a/host-frontend-root/frontend-src-root/vitest.config.ts
+++ b/host-frontend-root/frontend-src-root/vitest.config.ts
@@ -3,7 +3,9 @@ import { WxtVitest } from 'wxt/testing';
 import path from 'path';
 
 // WSL2環境の検出（WSL_DISTRO_NAMEはWSL2でのみ設定される）
-const isWSL2 = process.env.WSL_DISTRO_NAME !== undefined;
+const isWSL2 =
+  process.env.CI === undefined &&
+  process.env.WSL_DISTRO_NAME !== undefined;
 
 export default defineConfig({
   plugins: [WxtVitest()],


### PR DESCRIPTION
## 概要
vitest poolOptions.forks.maxForks=2 を設定し、WSL2環境でのOOM/ペーン消失リスクを低減する。

## 変更内容
- `host-frontend-root/frontend-src-root/vitest.config.ts` にpoolOptions追加
- maxForks: 2（デフォルト: CPUコア数最大16 → 2に制限）

## 背景
cmd_693 P-1対策。vitest ^3.1.2の並列実行でWSL2メモリ(16GB)が圧迫されOOMが発生していた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * WSL 環境（CI を除く）でのテスト実行において、並列実行方式をフォーク方式に切替え、実行時の最大フォーク数を2に制限する設定を追加しました。その他の環境では従来通りの並列挙動が維持されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->