### PR TITLE
feat: vitest排他制御ラッパー追加（OOM・同時実行防止）

### DIFF
--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -15,7 +15,7 @@
     "build:firefox": "wxt build -b firefox",
     "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
     "build-storybook": "storybook build",
-    "test:unit": "vitest --run",
+    "test:unit": "bash scripts/vitest-run.sh",
     "test:e2e": "playwright test --retries=2",
     "test:all": "npm run test:unit && npm run test:e2e",
     "zip": "wxt zip",

--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -15,7 +15,7 @@
     "build:firefox": "wxt build -b firefox",
     "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
     "build-storybook": "storybook build",
-    "test:unit": "bash scripts/vitest-run.sh",
+    "test:unit": "sh scripts/vitest-run.sh",
     "test:e2e": "playwright test --retries=2",
     "test:all": "npm run test:unit && npm run test:e2e",
     "zip": "wxt zip",

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 # vitest排他制御ラッパー（OOM防止・同時実行防止）
 # flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
-LOCK_FILE="/tmp/vitest-frog-frame-front.lock"
-if command -v flock &>/dev/null; then
+LOCK_FILE="${VITEST_LOCK_FILE:-${TMPDIR:-/tmp}/vitest-frog-frame-front.lock}"
+if command -v flock >/dev/null 2>&1; then
   echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
   exec flock -w 120 "$LOCK_FILE" \
     sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
-    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 else
   echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
-  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 fi

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# vitest排他制御ラッパー（OOM防止・同時実行防止）
+# flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
+LOCK_FILE="/tmp/vitest-frog-frame-front.lock"
+if command -v flock &>/dev/null; then
+  echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
+  exec flock -w 120 "$LOCK_FILE" \
+    sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
+    env NODE_OPTIONS="--max-old-space-size=2048" npx vitest run "$@"
+else
+  echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
+  exec env NODE_OPTIONS="--max-old-space-size=2048" npx vitest run "$@"
+fi

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -6,8 +6,8 @@ if command -v flock &>/dev/null; then
   echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
   exec flock -w 120 "$LOCK_FILE" \
     sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
-    env NODE_OPTIONS="--max-old-space-size=2048" npx vitest run "$@"
+    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
 else
   echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
-  exec env NODE_OPTIONS="--max-old-space-size=2048" npx vitest run "$@"
+  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
 fi


### PR DESCRIPTION
## 概要
cmd_693 P-2: vitest排他制御ラッパーの実装。

## 変更内容
- `scripts/vitest-run.sh` 新規作成: flockによる排他制御ラッパー
- `package.json`: `test:unit` を `bash scripts/vitest-run.sh` に変更

## 動作
- **WSL2**: flock検出 → 排他制御モード（複数足軽の同時実行を物理ロックで防止）
- **GitHub Actions CI**: flock検出されるが単一ジョブなので実質透過
- **Claude Code Web**: flock未検出 → 直接実行モード

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * テスト実行をラッパースクリプト経由に変更し、実行フローを統一しました。
  * 並列実行の競合を回避するロック制御を導入し、テストの安定性を向上しました。
  * 実行時にメモリ上限を設定して大規模テストでのメモリ不足を低減します。
  * ロック利用／直接実行のモードをログ出力し実行状況を可視化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->