### PR TITLE
feat: add vitest flock wrapper for OOM prevention (cmd_693 P-2)

### DIFF
--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -15,7 +15,7 @@
     "build:firefox": "wxt build -b firefox",
     "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
     "build-storybook": "storybook build",
-    "test:unit": "vitest --run",
+    "test:unit": "bash scripts/vitest-run.sh",
     "test:e2e": "playwright test --retries=2",
     "test:all": "npm run test:unit && npm run test:e2e",
     "zip": "wxt zip",

--- a/host-frontend-root/frontend-src-root/package.json
+++ b/host-frontend-root/frontend-src-root/package.json
@@ -15,7 +15,7 @@
     "build:firefox": "wxt build -b firefox",
     "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
     "build-storybook": "storybook build",
-    "test:unit": "bash scripts/vitest-run.sh",
+    "test:unit": "sh scripts/vitest-run.sh",
     "test:e2e": "playwright test --retries=2",
     "test:all": "npm run test:unit && npm run test:e2e",
     "zip": "wxt zip",

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# vitest排他制御ラッパー（OOM防止・同時実行防止）
+# flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
+LOCK_FILE="/tmp/vitest-frog-frame-front.lock"
+if command -v flock &>/dev/null; then
+  echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
+  exec flock -w 120 "$LOCK_FILE" \
+    sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
+    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+else
+  echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
+  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+fi

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 # vitest排他制御ラッパー（OOM防止・同時実行防止）
 # flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
-LOCK_FILE="/tmp/vitest-frog-frame-front.lock"
-if command -v flock &>/dev/null; then
+# WSL2/Linux環境専用スクリプト
+LOCK_FILE="${VITEST_LOCK_FILE:-${TMPDIR:-/tmp}/vitest-frog-frame-front.lock}"
+if command -v flock >/dev/null 2>&1; then
   echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
   exec flock -w 120 "$LOCK_FILE" \
     sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
-    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+    env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 else
   echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
-  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx vitest run "$@"
+  exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 fi

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vitest排他制御ラッパー（OOM防止・同時実行防止）
 # flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
-# WSL2/Linux環境専用スクリプト
+# POSIX sh が動作する Unix系環境向けスクリプト（主に WSL2/Linux を想定）
 LOCK_FILE="${VITEST_LOCK_FILE:-${TMPDIR:-/tmp}/vitest-frog-frame-front.lock}"
 if command -v flock >/dev/null 2>&1; then
   echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
@@ -9,6 +9,6 @@ if command -v flock >/dev/null 2>&1; then
     sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
     env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 else
-  echo "[vitest-run] flock未検出 → 直接実行モード（CI/Cloud環境）"
+  echo "[vitest-run] flock未検出 → 直接実行モード（flockがない環境）"
   exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
 fi

--- a/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
+++ b/host-frontend-root/frontend-src-root/scripts/vitest-run.sh
@@ -3,11 +3,19 @@
 # flock があれば排他制御、なければそのまま実行（CI/Claude Code Web互換）
 # POSIX sh が動作する Unix系環境向けスクリプト（主に WSL2/Linux を想定）
 LOCK_FILE="${VITEST_LOCK_FILE:-${TMPDIR:-/tmp}/vitest-frog-frame-front.lock}"
+# ロック取得待ち時間（秒）。CI環境での長時間テスト並行実行を考慮した上限値
+LOCK_WAIT="${VITEST_LOCK_WAIT:-120}"
 if command -v flock >/dev/null 2>&1; then
   echo "[vitest-run] flock検出 → 排他制御モード（$LOCK_FILE）"
-  exec flock -w 120 "$LOCK_FILE" \
+  flock -w "$LOCK_WAIT" -E 101 "$LOCK_FILE" \
     sh -c 'echo "[vitest-run] ロック取得成功（PID=$$）"; exec "$@"' -- \
     env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"
+  STATUS=$?
+  if [ "$STATUS" -eq 101 ]; then
+    echo "[vitest-run] ロック取得タイムアウト（${LOCK_WAIT}秒待機）: 他プロセスがロック中" >&2
+    exit 1
+  fi
+  exit "$STATUS"
 else
   echo "[vitest-run] flock未検出 → 直接実行モード（flockがない環境）"
   exec env NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048" npx --no-install vitest run "$@"


### PR DESCRIPTION
## Summary

- `scripts/vitest-run.sh` を新規追加: vitest排他制御ラッパー（OOM防止・同時実行防止）
- `package.json` の `test:unit` を `sh scripts/vitest-run.sh` に変更
- `NODE_OPTIONS` 既存値保持パターン `${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048` を採用（PR#401 CodeRabbit r2903199469 対応）

## 動作の仕組み

| 環境 | 動作 |
|------|------|
| WSL2（flock有り） | 排他制御モード: `/tmp/vitest-frog-frame-front.lock` で多重実行を防止 |
| CI/GitHub Actions（flock無し） | 直接実行モード: フォールバックで後退しない |
| Claude Code Web（flock無し） | 直接実行モード: 同上 |

## NODE_OPTIONS 既存値保持（r2903199469対応）

```bash
# NG: 既存NODE_OPTIONSを上書きしてしまう
NODE_OPTIONS="--max-old-space-size=2048"

# OK: 既存値を保持しつつ追加（空の場合は追加のみ）
NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=2048"
```

既存の `NODE_OPTIONS` が設定済みの場合はスペース区切りで追記、未設定の場合は `--max-old-space-size=2048` のみを設定。

## テスト結果

WSL2環境での全テスト実行結果:
```
Test Files  155 passed (155)
     Tests  533 passed (533)
SKIP  0 (SKIP=0確認済み)
```

## 関連

- cmd_693 P-2（vitest排他制御実装）
- PR#401 CodeRabbit comment r2903199469（NODE_OPTIONS上書き問題への対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ユニットテスト実行をシェルラッパー経由に切替え、実行時のメモリ上限を引き上げました。
  * 排他制御とタイムアウトを導入して並行実行時の競合を抑制します。
  * NODE_OPTIONS を尊重して既存環境を維持しつつ安定性を向上させました。
  * 実行ログ（日本語含む）を出力し、処理状況の可視化と CI/WSL2 等での互換性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->